### PR TITLE
Add HP/attack stats and ability data for PotD enemies.

### DIFF
--- a/_data/changelog.yml
+++ b/_data/changelog.yml
@@ -1,6 +1,10 @@
+- date: 2022-12-05
+  updates:
+    - 'Added PotD enemy stats and ability data, courtesy of vaxherd'
+    - 'Fixed Deep Palace Black Coeurl enemy name'
 - date: 2022-12-04
   updates:
-    - 'Show enemy ability potencies - currently all unknown, but will be 
+    - 'Show enemy ability potencies - currently all unknown, but will be
     added soon'
 - date: 2022-12-03
   updates:

--- a/_potd_001_enemies/antelope.md
+++ b/_potd_001_enemies/antelope.md
@@ -5,6 +5,9 @@ image: antelope.png
 start_floor: 1
 end_floor: 5
 agro: Sight
+hp: 149
+attack_damage: 10
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true

--- a/_potd_001_enemies/bat.md
+++ b/_potd_001_enemies/bat.md
@@ -5,10 +5,19 @@ image: bat.png
 start_floor: 3
 end_floor: 6
 agro: Sound
+hp: 201
+attack_damage: 16
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Blood Drain
+    potency: 100
+    description: 'pierces Steel; absorbs 50% of damage dealt'
+  - name: Ultrasonics
+    description: 'telegraphed conal AoE; inflicts accuracy down (12s)'
 ---

--- a/_potd_001_enemies/beetle.md
+++ b/_potd_001_enemies/beetle.md
@@ -5,10 +5,16 @@ image: beetle.png
 start_floor: 6
 end_floor: 9
 agro: Sight
+hp: 474
+attack_damage: 31
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Spoil
+    description: 'inflicts poison (DoT potency 20, 15s)'
 ---

--- a/_potd_001_enemies/coblyn.md
+++ b/_potd_001_enemies/coblyn.md
@@ -5,10 +5,17 @@ image: coblyn.png
 start_floor: 4
 end_floor: 8
 agro: Sight
+hp: 260
+attack_damage: 17
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Shatter
+    potency: 300
+    description: 'telegraphed pointblank AoE'
 ---

--- a/_potd_001_enemies/deathmouse.md
+++ b/_potd_001_enemies/deathmouse.md
@@ -5,10 +5,16 @@ image: deathmouse.png
 start_floor: 1
 end_floor: 4
 agro: Sight
+hp: 102
+attack_damage: 7
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Scamper
+    description: 'grants haste (30s) to self'
 ---

--- a/_potd_001_enemies/dung_beetle.md
+++ b/_potd_001_enemies/dung_beetle.md
@@ -6,10 +6,17 @@ start_floor: 6
 end_floor: 9
 patrol: true
 agro: Sight
+hp: 513
+attack_damage: 32
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Rhino Attack
+    potency: 250
+    description: 'gap closer (can be LoSed)'
 ---

--- a/_potd_001_enemies/goblin.md
+++ b/_potd_001_enemies/goblin.md
@@ -5,10 +5,18 @@ image: goblin.png
 start_floor: 4
 end_floor: 6
 agro: Sight
+hp: 291
+attack_damage: 17
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Bomb Toss
+    potency: 200
+    description: 'either a telegraphed circle AoE, or an untelegraphed
+    pointblank AoE which also damages the goblin itself'
 ---

--- a/_potd_001_enemies/hippocerf.md
+++ b/_potd_001_enemies/hippocerf.md
@@ -6,10 +6,17 @@ image: hippocerf.png
 start_floor: 5
 end_floor: 8
 agro: Sight
+hp: 358
+attack_damage: 26
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Shriek
+    potency: 200
+    description: 'telegraphed pointblank AoE; inflicts stun (6s)'
 ---

--- a/_potd_001_enemies/hornet.md
+++ b/_potd_001_enemies/hornet.md
@@ -5,6 +5,9 @@ image: hornet.png
 start_floor: 6
 end_floor: 9
 agro: Proximity
+hp: 557
+attack_damage: 40
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,6 +16,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Final Sting
-    description: 'Deals 70% max HP damage; used if not killed fast enough;
-    possible to outrange'
+    potency: 70% of max HP
+    description: 'sacrifial enrage; possible to outrange'
 ---

--- a/_potd_001_enemies/mimic.md
+++ b/_potd_001_enemies/mimic.md
@@ -3,8 +3,11 @@ name: Mimic
 nickname: Mimic
 image: ../mimic.png
 start_floor: 7
-end_floor: 10
+end_floor: 9
 agro: Proximity
+hp: 562
+attack_damage: 38
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,8 +17,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in bronze chests'

--- a/_potd_001_enemies/sprite.md
+++ b/_potd_001_enemies/sprite.md
@@ -5,6 +5,10 @@ image: sprite.png
 start_floor: 1
 end_floor: 3
 agro: Proximity
+hp: 80
+attack_damage: 7
+attack_type: Magic
+attack_name: Fire
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_001_enemies/yarzon.md
+++ b/_potd_001_enemies/yarzon.md
@@ -5,10 +5,16 @@ image: yarzon.png
 start_floor: 7
 end_floor: 9
 agro: Sound
+hp: 597
+attack_damage: 41
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: 'Corrosive Spit (?)'
+    description: 'instant; inflicts physical vulnerability up (50%, 20s)'
 ---

--- a/_potd_001_enemies/ziz.md
+++ b/_potd_001_enemies/ziz.md
@@ -6,10 +6,16 @@ start_floor: 1
 end_floor: 4
 patrol: true
 agro: Sight
+hp: 125
+attack_damage: 9
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Slumber Breath
+    description: 'telegraphed conal AoE; inflicts sleep (20s)'
 ---

--- a/_potd_011_enemies/biloko.md
+++ b/_potd_011_enemies/biloko.md
@@ -6,10 +6,17 @@ start_floor: 16
 end_floor: 19
 patrol: true
 agro: Sight
+hp: 1561
+attack_damage: 114
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: false
   slow: true
   stun: false
+abilities:
+  - name: The Wood Remembers
+    potency: 300
+    description: 'telegraphed conal AoE'
 ---

--- a/_potd_011_enemies/cobra.md
+++ b/_potd_011_enemies/cobra.md
@@ -5,6 +5,9 @@ image: cobra.png
 start_floor: 14
 end_floor: 17
 agro: Sight
+hp: 1027
+attack_damage: 81
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -12,8 +15,9 @@ vulnerabilities:
   slow: true
   stun: true
 abilities:
-  - name: 'Stone Gaze'
-    description: '360 degree gaze; applies petrify - look away'
+  - name: Stone Gaze
+    description: '360 degree gaze inflicting petrify (15s) - look away'
   - name: Devour
+    potency: 100% of max HP
     description: 'instant death; only used if you are a toad'
 ---

--- a/_potd_011_enemies/mimic.md
+++ b/_potd_011_enemies/mimic.md
@@ -5,6 +5,9 @@ image: ../mimic.png
 start_floor: 11
 end_floor: 19
 agro: Proximity
+hp: 1543
+attack_damage: 116
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,8 +17,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in bronze chests'

--- a/_potd_011_enemies/morbol.md
+++ b/_potd_011_enemies/morbol.md
@@ -5,6 +5,9 @@ image: morbol.png
 start_floor: 17
 end_floor: 19
 agro: Proximity
+hp: 1772
+attack_damage: 134
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -13,5 +16,15 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Bad Breath
-    description: 'telegraphed conal AoE; applies several status effects'
+    description: 'large telegraphed conal AoE; inflicts many debuffs'
+notes:
+  - note: 'Bad Breath inflicts these debuffs:'
+    subnotes:
+      - 'Poison (DoT potency 50, 30s)'
+      - 'Nausea (20s)'
+      - 'Slow (10s)'
+      - 'Blind (30s)'
+      - 'Heavy (20s)'
+      - 'Silence (10s)'
+      - 'Paralysis (30s)'
 ---

--- a/_potd_011_enemies/nanka.md
+++ b/_potd_011_enemies/nanka.md
@@ -5,6 +5,9 @@ image: nanka.png
 start_floor: 15
 end_floor: 18
 agro: Sound
+hp: 1121
+attack_damage: 48
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true

--- a/_potd_011_enemies/ninki_nanka.md
+++ b/_potd_011_enemies/ninki_nanka.md
@@ -5,6 +5,9 @@ image: ninki_nanka.png
 start_floor: 15
 end_floor: 18
 agro: Sound
+hp: 1027
+attack_damage: 81
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,5 +16,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Brackish Drop
+    potency: 650
     description: 'telegraphed circle AoE'
 ---

--- a/_potd_011_enemies/ochu.md
+++ b/_potd_011_enemies/ochu.md
@@ -5,10 +5,16 @@ image: ochu.png
 start_floor: 16
 end_floor: 19
 agro: Proximity
+hp: 1270
+attack_damage: 92
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Acid Mist
+    description: 'inflicts slow (12s)'
 ---

--- a/_potd_011_enemies/pudding.md
+++ b/_potd_011_enemies/pudding.md
@@ -6,12 +6,19 @@ start_floor: 11
 end_floor: 13
 patrol: true
 agro: Proximity
+hp: 688
+attack_damage: 45
+attack_type: Magic
+attack_name: Thunder
 vulnerabilities:
   bind: false
   heavy: false
   sleep: false
   slow: false
   stun: true
+abilities:
+  - name: Golden Tongue
+    description: 'grants magic damage up (50%, 15s) to self'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'
 ---

--- a/_potd_011_enemies/seedling.md
+++ b/_potd_011_enemies/seedling.md
@@ -5,10 +5,16 @@ image: seedling.png
 start_floor: 17
 end_floor: 19
 agro: Sound
+hp: 1350
+attack_damage: 65
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: true
+notes:
+  - 'Autoattack inflicts stacking poison (DoT potency 10 per stack, max 4
+    stacks, 9s)'
 ---

--- a/_potd_011_enemies/slime.md
+++ b/_potd_011_enemies/slime.md
@@ -5,6 +5,9 @@ image: slime.png
 start_floor: 13
 end_floor: 16
 agro: Sound
+hp: 904
+attack_damage: 67
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -12,7 +15,10 @@ vulnerabilities:
   slow: true
   stun: true
 abilities:
+  - name: Digest
+    potency: 100
+    description: 'absorbs 100% of damage dealt'
   - name: 'Rapture'
-    description: 'Enrage; explodes, doing huge AoE damage; used if not killed
-    quickly enough'
+    potency: 170% of max HP
+    description: 'instant AoE sacrificial enrage'
 ---

--- a/_potd_011_enemies/slime.md
+++ b/_potd_011_enemies/slime.md
@@ -18,7 +18,8 @@ abilities:
   - name: Digest
     potency: 100
     description: 'absorbs 100% of damage dealt'
-  - name: 'Rapture'
+  - name: Rapture
     potency: 170% of max HP
-    description: 'instant AoE sacrificial enrage'
+    description: 'instant AoE sacrificial enrage; used 20 seconds after
+    pull/aggro (immediately after the second Digest)'
 ---

--- a/_potd_011_enemies/spear-shaking_adventurer.md
+++ b/_potd_011_enemies/spear-shaking_adventurer.md
@@ -5,6 +5,9 @@ image: spear_adventurer.png
 start_floor: 11
 end_floor: 19
 agro: Proximity
+hp: 1330
+attack_damage: 104
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_011_enemies/staff-spinning_adventurer.md
+++ b/_potd_011_enemies/staff-spinning_adventurer.md
@@ -5,6 +5,9 @@ image: staff_adventurer.png
 start_floor: 11
 end_floor: 19
 agro: Proximity
+hp: 1455
+attack_damage: 125
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_011_enemies/sword-spinning_adventurer.md
+++ b/_potd_011_enemies/sword-spinning_adventurer.md
@@ -5,6 +5,9 @@ image: sword_adventurer.png
 start_floor: 11
 end_floor: 19
 agro: Proximity
+hp: 1543
+attack_damage: 118
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_011_enemies/toad.md
+++ b/_potd_011_enemies/toad.md
@@ -5,10 +5,21 @@ image: toad.png
 start_floor: 11
 end_floor: 15
 agro: Sight
+hp: 833
+attack_damage: 62
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Sticky Tongue
+    potency: 50
+    description: 'instant; draws the target in'
+  - name: Labored Leap
+    potency: 500
+    description: 'telegraphed pointblank AoE; used immediately after Sticky
+    Tongue'
 ---

--- a/_potd_011_enemies/uragnite.md
+++ b/_potd_011_enemies/uragnite.md
@@ -5,10 +5,16 @@ image: uragnite.png
 start_floor: 11
 end_floor: 14
 agro: Sight
+hp: 685
+attack_damage: 47
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: 'Gas Shell (?)'
+    description: 'inflicts poison (DoT potency 30, 12s)'
 ---

--- a/_potd_011_enemies/whelk.md
+++ b/_potd_011_enemies/whelk.md
@@ -6,10 +6,17 @@ image: whelk.png
 start_floor: 11
 end_floor: 13
 agro: Sight
+hp: 642
+attack_damage: 43
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: false
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Suction
+    potency: 130
+    description: 'instant'
 ---

--- a/_potd_021_enemies/adamantoise.md
+++ b/_potd_021_enemies/adamantoise.md
@@ -5,10 +5,17 @@ image: adamantoise.png
 start_floor: 21
 end_floor: 25
 agro: Sight
+hp: 2378
+attack_damage: 203
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
   sleep: true
   slow: true
   stun: false
+abilities:
+  - name: Tortoise Stomp
+    potency: 500
+    description: 'large telegraphed pointblank AoE'
 ---

--- a/_potd_021_enemies/centaur.md
+++ b/_potd_021_enemies/centaur.md
@@ -5,10 +5,19 @@ image: centaur.png
 start_floor: 26
 end_floor: 29
 agro: Proximity
+hp: 3172
+attack_damage: 401
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Berserk
+    description: 'grants damage up (50%, 20s) to self'
+  - name: Rear
+    potency: 200
+    description: 'telegraphed pointblank AoE'
 ---

--- a/_potd_021_enemies/drake.md
+++ b/_potd_021_enemies/drake.md
@@ -5,10 +5,16 @@ image: drake.png
 start_floor: 21
 end_floor: 24
 agro: Sight
+hp: 1976
+attack_damage: 148
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Smoldering Scales
+    description: 'grants counterattack (potency 200, 5s) to self'
 ---

--- a/_potd_021_enemies/dullahan.md
+++ b/_potd_021_enemies/dullahan.md
@@ -6,10 +6,17 @@ start_floor: 21
 end_floor: 23
 patrol: true
 agro: Sound
+hp: 1884
+attack_damage: 142
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Iron Justice
+    potency: 300
+    description: 'telegraphed conal AoE'
 ---

--- a/_potd_021_enemies/effigy.md
+++ b/_potd_021_enemies/effigy.md
@@ -5,10 +5,17 @@ image: effigy.png
 start_floor: 26
 end_floor: 29
 agro: Sight
+hp: 3488
+attack_damage: 297
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
   sleep: false
   slow: true
   stun: false
+abilities:
+  - name: Wild Horn
+    potency: 200
+    description: 'large telegraphed conal AoE; inflicts knockback'
 ---

--- a/_potd_021_enemies/frenzied_freebooter.md
+++ b/_potd_021_enemies/frenzied_freebooter.md
@@ -6,7 +6,7 @@ start_floor: 21
 end_floor: 29
 agro: Proximity
 hp: 3423
-attack_damage: 309?
+attack_damage: 309
 attack_type: Physical
 vulnerabilities:
   bind: false

--- a/_potd_021_enemies/frenzied_freebooter.md
+++ b/_potd_021_enemies/frenzied_freebooter.md
@@ -5,6 +5,9 @@ image: freebooter.png
 start_floor: 21
 end_floor: 29
 agro: Proximity
+hp: 3423
+attack_damage: 309?
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_021_enemies/ishgardian_pikeman.md
+++ b/_potd_021_enemies/ishgardian_pikeman.md
@@ -5,6 +5,9 @@ image: pikeman.png
 start_floor: 21
 end_floor: 29
 agro: Proximity
+hp: 3202
+attack_damage: 277
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_021_enemies/marolith.md
+++ b/_potd_021_enemies/marolith.md
@@ -5,10 +5,17 @@ image: marolith.png
 start_floor: 27
 end_floor: 29
 agro: Proximity
+hp: 3725
+attack_damage: 306
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Dark Blizzard III
+    potency: 200
+    description: 'telegraphed circle AoE'
 ---

--- a/_potd_021_enemies/mimic.md
+++ b/_potd_021_enemies/mimic.md
@@ -5,6 +5,9 @@ image: ../mimic.png
 start_floor: 21
 end_floor: 29
 agro: Proximity
+hp: 3857
+attack_damage: 335
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,8 +17,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in bronze chests'

--- a/_potd_021_enemies/minotaur.md
+++ b/_potd_021_enemies/minotaur.md
@@ -5,6 +5,9 @@ image: minotaur.png
 start_floor: 24
 end_floor: 26
 agro: Sight
+hp: 2465
+attack_damage: 212
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -12,6 +15,7 @@ vulnerabilities:
   slow: true
   stun: true
 abilities:
-  - name: '111-Tonze Swing'
-    description: 'Untelegraphed pointblank AoE causing damage and knockback'
+  - name: '111-tonze Swing'
+    potency: 600
+    description: 'untelegraphed pointblank AoE; inflicts knockback'
 ---

--- a/_potd_021_enemies/peiste.md
+++ b/_potd_021_enemies/peiste.md
@@ -5,10 +5,17 @@ image: peiste.png
 start_floor: 22
 end_floor: 25
 agro: Sight
+hp: 2459
+attack_damage: 202
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Stone Gaze
+    description: 'telegraphed conal gaze AoE inflicting petrify (15s) - look
+    away, get behind, or get away'
 ---

--- a/_potd_021_enemies/puk.md
+++ b/_potd_021_enemies/puk.md
@@ -5,10 +5,17 @@ image: puk.png
 start_floor: 21
 end_floor: 23
 agro: Sight
+hp: 1772
+attack_damage: 134
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Fireball
+    potency: 300
+    description: 'telegraphed circle AoE'
 ---

--- a/_potd_021_enemies/roughspun_ruffian.md
+++ b/_potd_021_enemies/roughspun_ruffian.md
@@ -5,6 +5,9 @@ image: ruffian.png
 start_floor: 21
 end_floor: 29
 agro: Proximity
+hp: 3613
+attack_damage: 308?
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_021_enemies/roughspun_ruffian.md
+++ b/_potd_021_enemies/roughspun_ruffian.md
@@ -6,7 +6,7 @@ start_floor: 21
 end_floor: 29
 agro: Proximity
 hp: 3613
-attack_damage: 308?
+attack_damage: 308
 attack_type: Physical
 vulnerabilities:
   bind: false

--- a/_potd_021_enemies/skatene.md
+++ b/_potd_021_enemies/skatene.md
@@ -5,6 +5,9 @@ image: skatene.png
 start_floor: 26
 end_floor: 29
 agro: Sound
+hp: 3358
+attack_damage: 286
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,5 +16,5 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Chirp
-    description: 'untelegraphed large pointblank AoE sleep'
+    description: 'untelegraphed large pointblank AoE; inflicts sleep (15s)'
 ---

--- a/_potd_021_enemies/spriggan.md
+++ b/_potd_021_enemies/spriggan.md
@@ -5,12 +5,19 @@ image: spriggan.png
 start_floor: 25
 end_floor: 28
 agro: Sight
+hp: 2790
+attack_damage: 242
+attack_type: Magic
+attack_name: Blizzard
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: false
   stun: true
+abilities:
+  - name: Haste
+    description: 'grants haste (30s) to self'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'
 ---

--- a/_potd_021_enemies/wivre.md
+++ b/_potd_021_enemies/wivre.md
@@ -5,10 +5,17 @@ image: wivre.png
 start_floor: 23
 end_floor: 26
 agro: Proximity
+hp: 2639
+attack_damage: 224
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Horrid Horn
+    potency: 130
+    description: 'instant'
 ---

--- a/_potd_031_enemies/bogy.md
+++ b/_potd_031_enemies/bogy.md
@@ -5,10 +5,17 @@ image: bogy.png
 start_floor: 31
 end_floor: 33
 agro: Sound
+hp: 3860
+attack_damage: 327
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Curse
+    potency: 200
+    description: 'telegraphed pointblank AoE; also deals 500 MP damage'
 ---

--- a/_potd_031_enemies/catoblepas.md
+++ b/_potd_031_enemies/catoblepas.md
@@ -5,10 +5,17 @@ image: catoblepas.png
 start_floor: 35
 end_floor: 37
 agro: Sight
+hp: 4148
+attack_damage: 389
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Quarry Lake
+    description: 'telegraphed conal gaze AoE inflicting petrify (15s) - look
+    away, get behind, or get away'
 ---

--- a/_potd_031_enemies/dahak.md
+++ b/_potd_031_enemies/dahak.md
@@ -5,10 +5,18 @@ image: dahak.png
 start_floor: 35
 end_floor: 38
 agro: Sight
+hp: 4087
+attack_damage: 383
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: 'Tail Drive (?)'
+    potency: 300
+    description: 'telegraphed backward conal AoE inflicting concussion (DoT
+    potency 30, 30s); used if someone is behind'
 ---

--- a/_potd_031_enemies/eye.md
+++ b/_potd_031_enemies/eye.md
@@ -7,12 +7,20 @@ start_floor: 34
 end_floor: 38
 patrol: true
 agro: Sight
+hp: 3921
+attack_damage: 367
+attack_type: Magic
+attack_name: Stone
 vulnerabilities:
   bind: false
   heavy: false
   sleep: false
   slow: false
   stun: true
+abilities:
+  - name: Eyes on Me
+    potency: 150
+    description: 'untelegraphed pointblank AoE'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'
 ---

--- a/_potd_031_enemies/gourmand.md
+++ b/_potd_031_enemies/gourmand.md
@@ -6,10 +6,17 @@ start_floor: 37
 end_floor: 39
 patrol: true
 agro: Proximity
+hp: 3996
+attack_damage: 423
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Beatdown
+    potency: 130
+    description: 'instant'
 ---

--- a/_potd_031_enemies/haagenti.md
+++ b/_potd_031_enemies/haagenti.md
@@ -5,10 +5,17 @@ image: haagenti.png
 start_floor: 37
 end_floor: 39
 agro: Sight
+hp: 4053
+attack_damage: 407
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Triclip
+    potency: 120
+    description: 'instant'
 ---

--- a/_potd_031_enemies/hecteyes.md
+++ b/_potd_031_enemies/hecteyes.md
@@ -17,5 +17,5 @@ vulnerabilities:
 abilities:
   - name: Hex Eye
     potency: 200
-    description: 'telegraphed pointblank AoE'
+    description: 'telegraphed pointblank AoE; inflicts paralysis (15s)'
 ---

--- a/_potd_031_enemies/hecteyes.md
+++ b/_potd_031_enemies/hecteyes.md
@@ -5,10 +5,17 @@ image: hecteyes.png
 start_floor: 31
 end_floor: 35
 agro: Sound
+hp: 4245
+attack_damage: 358
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Hex Eye
+    potency: 200
+    description: 'telegraphed pointblank AoE'
 ---

--- a/_potd_031_enemies/immortal_flame.md
+++ b/_potd_031_enemies/immortal_flame.md
@@ -5,8 +5,8 @@ family: Fallen NPC
 start_floor: 31
 end_floor: 39
 agro: Proximity
-hp: 5160?
-attack_damage: 520?
+hp: 5160
+attack_damage: 520
 attack_type: Physical
 vulnerabilities:
   bind: false

--- a/_potd_031_enemies/immortal_flame.md
+++ b/_potd_031_enemies/immortal_flame.md
@@ -5,6 +5,9 @@ family: Fallen NPC
 start_floor: 31
 end_floor: 39
 agro: Proximity
+hp: 5160?
+attack_damage: 520?
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_031_enemies/mimic.md
+++ b/_potd_031_enemies/mimic.md
@@ -5,6 +5,9 @@ image: ../mimic.png
 start_floor: 31
 end_floor: 39
 agro: Proximity
+hp: 5268
+attack_damage: 492
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,8 +17,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in silver chests'

--- a/_potd_031_enemies/monk.md
+++ b/_potd_031_enemies/monk.md
@@ -6,12 +6,22 @@ image: monk.png
 start_floor: 36
 end_floor: 39
 agro: Proximity
+hp: 4148
+attack_damage: 389
+attack_type: Magic
+attack_name: Water
 vulnerabilities:
   bind: true
   heavy: false
   sleep: false
   slow: false
   stun: true
+abilities:
+  - name: Sucker
+    description: 'large untelegraphed pointblank AoE; draws players in'
+  - name: Flood
+    potency: 250
+    description: 'telegraphed pointblank AoE; used immediately after Sucker'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'
 ---

--- a/_potd_031_enemies/mummy.md
+++ b/_potd_031_enemies/mummy.md
@@ -5,10 +5,17 @@ image: mummy.png
 start_floor: 33
 end_floor: 36
 agro: Proximity
+hp: 3890
+attack_damage: 351
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Rotting Bandages
+    potency: 130
+    description: 'telegraphed conal AoE; inflicts stun (6s)'
 ---

--- a/_potd_031_enemies/ogre.md
+++ b/_potd_031_enemies/ogre.md
@@ -5,10 +5,17 @@ image: ogre.png
 start_floor: 31
 end_floor: 35
 agro: Sight
+hp: 3879
+attack_damage: 343
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: false
+abilities:
+  - name: Heartburn
+    potency: 300
+    description: 'large telegraphed circle AoE'
 ---

--- a/_potd_031_enemies/succubus.md
+++ b/_potd_031_enemies/succubus.md
@@ -6,6 +6,9 @@ start_floor: 31
 end_floor: 35
 patrol: true
 agro: Sight
+hp: 3890
+attack_damage: 351
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,7 +17,9 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Dark Mist
-    description: 'telegraphed pointblank AoE cuasing terror'
-  - name: 'Void Fire II'
-    description: 'telegraphed circle AoE; casted immediately after Dark Mist'
+    potency: 300
+    description: 'large telegraphed pointblank AoE; inflicts terror (10s)'
+  - name: Void Fire II
+    potency: 300
+    description: 'telegraphed circle AoE; used immediately after Dark Mist'
 ---

--- a/_potd_031_enemies/troubadour.md
+++ b/_potd_031_enemies/troubadour.md
@@ -5,6 +5,10 @@ image: troubadour.png
 start_floor: 36
 end_floor: 39
 agro: Proximity
+hp: 3992
+attack_damage: 398
+attack_type: Magic
+attack_name: Dark
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_041_enemies/bhoot.md
+++ b/_potd_041_enemies/bhoot.md
@@ -5,6 +5,9 @@ image: bhoot.png
 start_floor: 43
 end_floor: 46
 agro: Sound
+hp: 3873
+attack_damage: 444
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,5 +16,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Paralyze III'
-    description: 'huge pointblank AoE causing paralyze; can be interrupted'
+    description: 'huge untelegraphed pointblank AoE inflicting paralysis (15s);
+    can be interrupted'
 ---

--- a/_potd_041_enemies/bloodguard.md
+++ b/_potd_041_enemies/bloodguard.md
@@ -5,10 +5,20 @@ image: bloodguard.png
 start_floor: 46
 end_floor: 49
 agro: Sight
+hp: 4205
+attack_damage: 469
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: false
   slow: true
   stun: false
+abilities:
+  - name: Void Slash
+    potency: 100
+    description: 'instant'
+  - name: Void Trap
+    potency: 300
+    description: 'telegraphed circle AoE'
 ---

--- a/_potd_041_enemies/demon.md
+++ b/_potd_041_enemies/demon.md
@@ -5,10 +5,17 @@ image: demon.png
 start_floor: 41
 end_floor: 43
 agro: Sight
+hp: 3996
+attack_damage: 423
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Dark Dome
+    potency: 90
+    description: 'instant'
 ---

--- a/_potd_041_enemies/dragon.md
+++ b/_potd_041_enemies/dragon.md
@@ -5,10 +5,17 @@ image: dragon.png
 start_floor: 47
 end_floor: 49
 agro: Sight
+hp: 4316
+attack_damage: 486
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: false
   slow: true
   stun: false
+abilities:
+  - name: Dark Thorn
+    potency: 90
+    description: 'telegraphed circle AoE'
 ---

--- a/_potd_041_enemies/duskwight_lancer.md
+++ b/_potd_041_enemies/duskwight_lancer.md
@@ -5,6 +5,9 @@ image: duskwight_lancer.png
 start_floor: 41
 end_floor: 49
 agro: Proximity
+hp: 5755
+attack_damage: 616?
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_041_enemies/duskwight_lancer.md
+++ b/_potd_041_enemies/duskwight_lancer.md
@@ -6,7 +6,7 @@ start_floor: 41
 end_floor: 49
 agro: Proximity
 hp: 5755
-attack_damage: 616?
+attack_damage: 616
 attack_type: Physical
 vulnerabilities:
   bind: false

--- a/_potd_041_enemies/gargoyle.md
+++ b/_potd_041_enemies/gargoyle.md
@@ -5,10 +5,17 @@ image: gargoyle.png
 start_floor: 41
 end_floor: 45
 agro: Sight
+hp: 3985
+attack_damage: 428
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Grim Reaper
+    potency: 90
+    description: 'instant'
 ---

--- a/_potd_041_enemies/gnat.md
+++ b/_potd_041_enemies/gnat.md
@@ -5,12 +5,19 @@ image: gnat.png
 start_floor: 41
 end_floor: 43
 agro: Sight
+hp: 4053
+attack_damage: 407
+attack_type: Magic
 vulnerabilities:
   bind: false
   heavy: false
   sleep: false
   slow: false
   stun: true
+abilities:
+  - name: Thunderstrike
+    potency: 300
+    description: 'telegraphed line AoE'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'
 ---

--- a/_potd_041_enemies/gravekeeper.md
+++ b/_potd_041_enemies/gravekeeper.md
@@ -6,10 +6,17 @@ patrol: true
 start_floor: 47
 end_floor: 49
 agro: Sound
+hp: 4427
+attack_damage: 493
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: false
   stun: false
+abilities:
+  - name: Nail in the Coffin
+    potency: 150
+    description: 'instant'
 ---

--- a/_potd_041_enemies/hellhound.md
+++ b/_potd_041_enemies/hellhound.md
@@ -5,10 +5,17 @@ image: hellhound.png
 start_floor: 45
 end_floor: 48
 agro: Sight
+hp: 3984
+attack_damage: 459
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Ravenous Bite
+    potency: 110
+    description: 'instant'
 ---

--- a/_potd_041_enemies/knight.md
+++ b/_potd_041_enemies/knight.md
@@ -5,10 +5,16 @@ image: knight.png
 start_floor: 42
 end_floor: 46
 agro: Proximity
+hp: 3873
+attack_damage: 444
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Ossify
+    description: 'grants damage up (100%, 8s) to self'
 ---

--- a/_potd_041_enemies/manticore.md
+++ b/_potd_041_enemies/manticore.md
@@ -18,7 +18,7 @@ vulnerabilities:
 abilities:
   - name: Ripper Claw
     potency: 300
-    description: 'untelegraphed conal AoE - don't stand in front!'
+    description: 'untelegraphed conal AoE - don''t stand in front!'
   - name: Fireball
     potency: 300
     description: 'telegraphed circle AoE'

--- a/_potd_041_enemies/manticore.md
+++ b/_potd_041_enemies/manticore.md
@@ -6,10 +6,20 @@ start_floor: 41
 end_floor: 43
 patrol: true
 agro: Sight
+hp: 3984
+attack_damage: 459
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Ripper Claw
+    potency: 300
+    description: 'untelegraphed conal AoE - don't stand in front!'
+  - name: Fireball
+    potency: 300
+    description: 'telegraphed circle AoE'
 ---

--- a/_potd_041_enemies/mimic.md
+++ b/_potd_041_enemies/mimic.md
@@ -5,6 +5,9 @@ image: ../mimic.png
 start_floor: 41
 end_floor: 49
 agro: Proximity
+hp: 5755
+attack_damage: 632
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,8 +17,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_041_enemies/persona.md
+++ b/_potd_041_enemies/persona.md
@@ -5,6 +5,9 @@ image: persona.png
 start_floor: 46
 end_floor: 49
 agro: Sight
+hp: 3984
+attack_damage: 459
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,5 +16,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Paralyze III'
-    description: 'huge pointblank AoE causing paralyze; can be interrupted'
+    description: 'huge untelegraphed pointblank AoE inflicting paralysis (15s);
+    can be interrupted'
 ---

--- a/_potd_041_enemies/wraith.md
+++ b/_potd_041_enemies/wraith.md
@@ -6,6 +6,9 @@ start_floor: 44
 end_floor: 46
 patrol: true
 agro: Proximity
+hp: 4316
+attack_damage: 486
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,5 +17,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Scream
-    description: 'huge telegraphed pointblank AoE causing terror'
+    potency: 200
+    description: 'huge telegraphed pointblank AoE; inflicts terror (15s); can
+    be interrupted'
 ---

--- a/_potd_051_enemies/anubys.md
+++ b/_potd_051_enemies/anubys.md
@@ -6,6 +6,9 @@ start_floor: 51
 end_floor: 53
 patrol: true
 agro: Sight
+hp: 4759
+attack_damage: 463
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,4 +16,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Spellsword
+    potency: 300
+    description: 'telegraphed conal AoE'
 ---

--- a/_potd_051_enemies/arch_demon.md
+++ b/_potd_051_enemies/arch_demon.md
@@ -6,6 +6,9 @@ start_floor: 57
 end_floor: 59
 patrol: true
 agro: Proximity
+hp: 5312
+attack_damage: 546
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,4 +16,11 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Abyssal Transfixion
+    potency: 130
+    description: 'instant'
+  - name: Abyssal Swing
+    potency: 300
+    description: 'telegraphed conal AoE'
 ---

--- a/_potd_051_enemies/blackening_marketeer.md
+++ b/_potd_051_enemies/blackening_marketeer.md
@@ -6,7 +6,7 @@ start_floor: 51
 end_floor: 59
 agro: Proximity
 hp: 6087
-attack_damage: 674?
+attack_damage: 674
 attack_type: Physical
 vulnerabilities:
   bind: false

--- a/_potd_051_enemies/blackening_marketeer.md
+++ b/_potd_051_enemies/blackening_marketeer.md
@@ -5,6 +5,9 @@ image: marketeer.png
 start_floor: 51
 end_floor: 59
 agro: Proximity
+hp: 6087
+attack_damage: 674?
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_051_enemies/deepeye.md
+++ b/_potd_051_enemies/deepeye.md
@@ -5,6 +5,9 @@ image: deepeye.png
 start_floor: 51
 end_floor: 55
 agro: Sight
+hp: 4357
+attack_damage: 499
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,4 +15,10 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Optical Intrusion
+    potency: 130
+    description: 'instant'
+  - name: Hypnotize
+    description: 'roomwide gaze attack inflicting paralysis (30s) - look away'
 ---

--- a/_potd_051_enemies/gremlin.md
+++ b/_potd_051_enemies/gremlin.md
@@ -5,6 +5,9 @@ image: gremlin.png
 start_floor: 51
 end_floor: 55
 agro: Sight
+hp: 4759
+attack_damage: 516
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -12,4 +15,10 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Bad Mouth
+    description: 'instant; inflicts vulnerability up (25%, 10s)'
+  - name: Fire II
+    potency: 300
+    description: 'telegraphed circle AoE'
 ---

--- a/_potd_051_enemies/idol.md
+++ b/_potd_051_enemies/idol.md
@@ -6,6 +6,9 @@ start_floor: 54
 end_floor: 57
 patrol: true
 agro: Proximity
+hp: 5312
+attack_damage: 534
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,4 +16,11 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Carpomission
+    potency: 130
+    description: 'instant'
+  - name: Neck Splinter
+    potency: 300
+    description: 'telegraphed pointblank AoE'
 ---

--- a/_potd_051_enemies/imp.md
+++ b/_potd_051_enemies/imp.md
@@ -5,6 +5,10 @@ image: imp.png
 start_floor: 53
 end_floor: 56
 agro: Sight
+hp: 4759
+attack_damage: 517
+attack_type: Magic
+attack_name: Blizzard
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,6 +16,10 @@ vulnerabilities:
   slow: false
   stun: true
   resolution: false
+abilities:
+  - name: Ice Spikes
+    description: 'grants counterattack (potency 200, 5s) to self; can be
+    interrupted'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'
 ---

--- a/_potd_051_enemies/mimic.md
+++ b/_potd_051_enemies/mimic.md
@@ -5,6 +5,9 @@ image: ../mimic.png
 start_floor: 51
 end_floor: 59
 agro: Proximity
+hp: 6862
+attack_damage: 706
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_051_enemies/moldering_merchant.md
+++ b/_potd_051_enemies/moldering_merchant.md
@@ -6,7 +6,7 @@ start_floor: 51
 end_floor: 59
 agro: Proximity
 hp: 6087
-attack_damage: 671?
+attack_damage: 671
 attack_type: Physical
 vulnerabilities:
   bind: false

--- a/_potd_051_enemies/moldering_merchant.md
+++ b/_potd_051_enemies/moldering_merchant.md
@@ -5,6 +5,9 @@ image: merchant.png
 start_floor: 51
 end_floor: 59
 agro: Proximity
+hp: 6087
+attack_damage: 671?
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_051_enemies/pot.md
+++ b/_potd_051_enemies/pot.md
@@ -5,6 +5,9 @@ image: pot.png
 start_floor: 54
 end_floor: 58
 agro: Proximity
+hp: 4980
+attack_damage: 520
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,4 +15,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Mysterious Light
+    potency: 450
+    description: 'roomwide gaze attack inflicting blind (15s) - look away'
 ---

--- a/_potd_051_enemies/pudding.md
+++ b/_potd_051_enemies/pudding.md
@@ -5,6 +5,10 @@ image: pudding.png
 start_floor: 51
 end_floor: 53
 agro: Proximity
+hp: 4537
+attack_damage: 499
+attack_type: Magic
+attack_name: Blizzard
 vulnerabilities:
   bind: false
   heavy: false
@@ -12,6 +16,9 @@ vulnerabilities:
   slow: false
   stun: true
   resolution: false
+abilities:
+  - name: Golden Tongue
+    description: 'grants magic damage up (50%, 15s) to self'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'
 ---

--- a/_potd_051_enemies/soulflayer.md
+++ b/_potd_051_enemies/soulflayer.md
@@ -5,6 +5,9 @@ image: soulflayer.png
 start_floor: 57
 end_floor: 59
 agro: Sight
+hp: 5201
+attack_damage: 541
+attack_type: Magic
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,6 +15,13 @@ vulnerabilities:
   slow: false
   stun: true
   resolution: false
+abilities:
+  - name: Mind Blast
+    potency: 300
+    description: 'telegraphed pointblank AoE; inflicts paralysis (15s)'
+  - name: 'Canker (?)'
+    description: 'instant enrage; inflicts disease (15s) with strong heavy
+    effect'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'
 ---

--- a/_potd_051_enemies/taurus.md
+++ b/_potd_051_enemies/taurus.md
@@ -5,6 +5,9 @@ image: taurus.png
 start_floor: 55
 end_floor: 59
 agro: Sight
+hp: 4980
+attack_damage: 517
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,4 +15,9 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Frightful Roar
+    potency: 300
+    description: 'telegraphed pointblank AoE; inflicts vulnerability up (20%,
+    30s)'
 ---

--- a/_potd_051_enemies/vodoriga.md
+++ b/_potd_051_enemies/vodoriga.md
@@ -5,6 +5,9 @@ image: vodoriga.png
 start_floor: 56
 end_floor: 59
 agro: Sight
+hp: 5312
+attack_damage: 528
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -12,4 +15,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Terror Eye
+    potency: 300
+    description: 'telegraphed circle AoE'
 ---

--- a/_potd_061_enemies/blade.md
+++ b/_potd_061_enemies/blade.md
@@ -6,6 +6,9 @@ start_floor: 64
 end_floor: 66
 patrol: true
 agro: Sight
+hp: 5534
+attack_damage: 564
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,4 +16,12 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Third Leg Forward
+    potency: 300
+    description: 'telegraphed conal AoE'
+  - name: Third Leg Back
+    potency: 300
+    description: 'telegraphed backward conal AoE; inflicts knockback; used
+    after Third Leg Forward if someone is behind'
 ---

--- a/_potd_061_enemies/bloated_archer.md
+++ b/_potd_061_enemies/bloated_archer.md
@@ -5,6 +5,9 @@ image: bloated_archer.png
 start_floor: 61
 end_floor: 69
 agro: Proximity
+hp: 6972?
+attack_damage: 746
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_061_enemies/bloated_archer.md
+++ b/_potd_061_enemies/bloated_archer.md
@@ -5,7 +5,7 @@ image: bloated_archer.png
 start_floor: 61
 end_floor: 69
 agro: Proximity
-hp: 6972?
+hp: 6972
 attack_damage: 746
 attack_type: Physical
 vulnerabilities:

--- a/_potd_061_enemies/bloated_conjurer.md
+++ b/_potd_061_enemies/bloated_conjurer.md
@@ -5,6 +5,9 @@ image: bloated_conjurer.png
 start_floor: 61
 end_floor: 69
 agro: Proximity
+hp: 7192
+attack_damage: 292
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_061_enemies/bloated_pugilist.md
+++ b/_potd_061_enemies/bloated_pugilist.md
@@ -5,6 +5,9 @@ image: bloated_pugilist.png
 start_floor: 61
 end_floor: 69
 agro: Proximity
+hp: 7526
+attack_damage: 297
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_061_enemies/croc.md
+++ b/_potd_061_enemies/croc.md
@@ -5,6 +5,9 @@ image: croc.png
 start_floor: 64
 end_floor: 68
 agro: Sight
+hp: 5534
+attack_damage: 564
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,5 +17,10 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Flatten
+    potency: 300
     description: 'telegraphed conal AoE'
+  - name: 'Caudal Swipe (?)'
+    potency: 300
+    description: 'telegraphed backward conal AoE inflicting stun (3s) and
+    knockback; used if someone is behind'
 ---

--- a/_potd_061_enemies/diplocaulus.md
+++ b/_potd_061_enemies/diplocaulus.md
@@ -5,6 +5,9 @@ image: diplocaulus.png
 start_floor: 65
 end_floor: 69
 agro: Proximity
+hp: 5755
+attack_damage: 569
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,4 +15,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Foregone Gleam
+    description: 'untelegraphed conal gaze AoE inflicting paralysis (20s) -
+    look away, get behind, or get away'
 ---

--- a/_potd_061_enemies/elbst.md
+++ b/_potd_061_enemies/elbst.md
@@ -6,6 +6,9 @@ start_floor: 61
 end_floor: 63
 patrol: true
 agro: Sight
+hp: 5201
+attack_damage: 540
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,4 +16,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Acid Shower
+    potency: 130
+    description: 'instant; inflicts vulnerability up (30%, 10s)'
 ---

--- a/_potd_061_enemies/mimic.md
+++ b/_potd_061_enemies/mimic.md
@@ -5,6 +5,9 @@ image: ../mimic.png
 start_floor: 61
 end_floor: 69
 agro: Proximity
+hp: 7747
+attack_damage: 763
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_061_enemies/mylodon.md
+++ b/_potd_061_enemies/mylodon.md
@@ -6,6 +6,9 @@ start_floor: 67
 end_floor: 69
 patrol: true
 agro: Sight
+hp: 5976
+attack_damage: 585
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,4 +16,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Slowball
+    potency: 300
+    description: 'telegraphed circle AoE'
 ---

--- a/_potd_061_enemies/pteranodon.md
+++ b/_potd_061_enemies/pteranodon.md
@@ -5,6 +5,9 @@ image: pteranodon.png
 start_floor: 67
 end_floor: 69
 agro: Proximity
+hp: 5866
+attack_damage: 574
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,4 +15,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Lightning Bolt
+    potency: 300
+    description: 'telegraphed circle AoE'
 ---

--- a/_potd_061_enemies/raptor.md
+++ b/_potd_061_enemies/raptor.md
@@ -5,6 +5,9 @@ image: raptor.png
 start_floor: 61
 end_floor: 63
 agro: Sight
+hp: 5312
+attack_damage: 546
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,5 +17,6 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Foul Breath
-    description: 'telegraphed conal AoE; applies Burns (DoT)'
+    potency: 300
+    description: 'telegraphed conal AoE; inflicts burns (DoT potency 30, 12s)'
 ---

--- a/_potd_061_enemies/sarcosuchus.md
+++ b/_potd_061_enemies/sarcosuchus.md
@@ -5,6 +5,9 @@ image: sarcosuchus.png
 start_floor: 61
 end_floor: 66
 agro: Sight
+hp: 5534
+attack_damage: 558
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,4 +15,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Critical Bite
+    potency: 300
+    description: 'telegraphed conal AoE'
 ---

--- a/_potd_061_enemies/triceratops.md
+++ b/_potd_061_enemies/triceratops.md
@@ -5,6 +5,9 @@ image: triceratops.png
 start_floor: 66
 end_floor: 69
 agro: Proximity
+hp: 5755
+attack_damage: 569
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -12,4 +15,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Batterhorn
+    potency: 130
+    description: 'instant'
 ---

--- a/_potd_061_enemies/tyrannosaur.md
+++ b/_potd_061_enemies/tyrannosaur.md
@@ -5,6 +5,9 @@ image: tyrannosaur.png
 start_floor: 61
 end_floor: 64
 agro: Sight
+hp: 5312
+attack_damage: 546
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -13,6 +16,10 @@ vulnerabilities:
   stun: true
   resolution: false
 abilities:
-  - name: 'Primordial Roar'
-    description: 'telegraphed pointblank AoE; applies Stun'
+  - name: Underbite
+    potency: 130
+    description: 'instant'
+  - name: Primordial Roar
+    potency: 300
+    description: 'telegraphed pointblank AoE; inflicts stun (4s)'
 ---

--- a/_potd_061_enemies/wivre.md
+++ b/_potd_061_enemies/wivre.md
@@ -5,6 +5,9 @@ image: wivre.png
 start_floor: 63
 end_floor: 66
 agro: Proximity
+hp: 5534
+attack_damage: 558
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -12,4 +15,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilites:
+  - name: Horrid Horn
+    potency: 130
+    description: 'instant'
 ---

--- a/_potd_071_enemies/anzu.md
+++ b/_potd_071_enemies/anzu.md
@@ -6,6 +6,9 @@ start_floor: 71
 end_floor: 73
 patrol: true
 agro: Sight
+hp: 6198
+attack_damage: 597
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,4 +16,11 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: 'Sonic Boom (?)'
+    description: 'instant; inflicts windburn (DoT potency 30, 20s)'
+  - name: Flying Frenzy
+    potency: 180
+    description: 'instant circle AoE gap closer; inflicts stun (2s) and
+    vulnerability up (50%, 10s); used when HP is below 30%'
 ---

--- a/_potd_071_enemies/aurochs.md
+++ b/_potd_071_enemies/aurochs.md
@@ -5,6 +5,9 @@ image: aurochs.png
 start_floor: 75
 end_floor: 79
 agro: Sight
+hp: 6640
+attack_damage: 631
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -12,4 +15,8 @@ vulnerabilities:
   slow: true
   stun: false
   resolution: false
+abilities:
+  - name: Seismic Rift
+    potency: 300
+    description: 'telegraphed pointblank AoE'
 ---

--- a/_potd_071_enemies/bandersnatch.md
+++ b/_potd_071_enemies/bandersnatch.md
@@ -5,6 +5,9 @@ image: bandersnatch.png
 start_floor: 71
 end_floor: 75
 agro: Sight
+hp: 6308
+attack_damage: 607
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,4 +15,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Catching Claws
+    potency: 130
+    description: 'instant'
 ---

--- a/_potd_071_enemies/bear.md
+++ b/_potd_071_enemies/bear.md
@@ -5,6 +5,9 @@ image: bear.png
 start_floor: 71
 end_floor: 75
 agro: Sight
+hp: 6198
+attack_damage: 597
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,4 +15,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Savage Swipe
+    potency: 300
+    description: 'telegraphed conal AoE'
 ---

--- a/_potd_071_enemies/bird.md
+++ b/_potd_071_enemies/bird.md
@@ -6,6 +6,9 @@ start_floor: 76
 end_floor: 79
 patrol: true
 agro: Proximity
+hp: 6862
+attack_damage: 653
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,4 +16,11 @@ vulnerabilities:
   slow: false
   stun: false
   resolution: false
+abilities:
+  - name: Filoplumes
+    potency: 130
+    description: 'instant'
+  - name: Revelation
+    potency: 300
+    description: 'telegraphed circle AoE; inflicts confused (10s)'
 ---

--- a/_potd_071_enemies/coeurl.md
+++ b/_potd_071_enemies/coeurl.md
@@ -5,6 +5,9 @@ image: coeurl.png
 start_floor: 76
 end_floor: 79
 agro: Sight
+hp: 6751
+attack_damage: 648
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,4 +15,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Megablaster
+    potency: 300
+    description: 'telegraphed conal AoE; inflicts paralysis (15s)'
 ---

--- a/_potd_071_enemies/cyclops.md
+++ b/_potd_071_enemies/cyclops.md
@@ -6,6 +6,9 @@ start_floor: 74
 end_floor: 76
 patrol: true
 agro: Sight
+hp: 6640
+attack_damage: 624
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -13,4 +16,12 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Eye of the Beholder
+    potency: 300
+    description: 'huge untelegraphed 270 degree donut AoE inflicting
+    electrocution (DoT potency 30, 12s) - get in or get behind'
+  - name: 100-tonze Swing
+    potency: 600
+    description: 'untelegraphed pointblank AoE; inflicts knockback'
 ---

--- a/_potd_071_enemies/dhalmel.md
+++ b/_potd_071_enemies/dhalmel.md
@@ -5,6 +5,9 @@ image: dhalmel.png
 start_floor: 73
 end_floor: 76
 agro: Proximity
+hp: 6530
+attack_damage: 619
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,4 +15,10 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Whiplash
+    potency: 300
+    description: 'telegraphed conal AoE'
+  - name: Whistle
+    description: 'grants physical damage up (50%, 15s) to self'
 ---

--- a/_potd_071_enemies/emaciated_engineer.md
+++ b/_potd_071_enemies/emaciated_engineer.md
@@ -5,6 +5,9 @@ image: emaciated_engineer.png
 start_floor: 71
 end_floor: 79
 agro: Proximity
+hp: 8079
+attack_damage: 774
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_071_enemies/lion.md
+++ b/_potd_071_enemies/lion.md
@@ -5,6 +5,8 @@ image: lion.png
 start_floor: 76
 end_floor: 79
 agro: Sight
+hp: 6751
+attack_damage: 648
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,4 +14,11 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Pounce
+    potency: 130
+    description: 'instant'
+  - name: Cry
+    potency: 300
+    description: 'large telegraphed pointblank AoE'
 ---

--- a/_potd_071_enemies/mimic.md
+++ b/_potd_071_enemies/mimic.md
@@ -5,6 +5,9 @@ image: ../mimic.png
 start_floor: 71
 end_floor: 79
 agro: Proximity
+hp: 8965
+attack_damage: 857
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_071_enemies/putrid_plutocrat.md
+++ b/_potd_071_enemies/putrid_plutocrat.md
@@ -5,6 +5,9 @@ image: putrid_plutocrat.png
 start_floor: 71
 end_floor: 79
 agro: Proximity
+hp: 8522
+attack_damage: 761
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_071_enemies/sasquatch.md
+++ b/_potd_071_enemies/sasquatch.md
@@ -5,6 +5,9 @@ image: sasquatch.png
 start_floor: 74
 end_floor: 77
 agro: Proximity
+hp: 6648
+attack_damage: 631
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -12,4 +15,11 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Stool Pelt
+    potency: 300
+    description: 'telegraphed circle AoE'
+  - name: Ripe Banana
+    description: 'grants physical damage up (100%, 15s) to self and heals 80%
+    of max HP; only used out of combat'
 ---

--- a/_potd_071_enemies/wolf.md
+++ b/_potd_071_enemies/wolf.md
@@ -5,6 +5,9 @@ image: wolf.png
 start_floor: 71
 end_floor: 74
 agro: Sight
+hp: 5976
+attack_damage: 584
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,4 +15,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Sanguine Bite
+    potency: 130
+    description: 'instant; absorbs 100% of damage dealt'
 ---

--- a/_potd_081_enemies/bomb.md
+++ b/_potd_081_enemies/bomb.md
@@ -18,5 +18,6 @@ vulnerabilities:
 abilities:
   - name: 'Self-destruct'
     potency: 70% of max HP
-    description: 'instant enrage AoE; used 37 seconds after aggro'
+    description: 'instant AoE sacrifical enrage; used 37 seconds after
+    pull/aggro'
 ---

--- a/_potd_081_enemies/bomb.md
+++ b/_potd_081_enemies/bomb.md
@@ -5,6 +5,9 @@ image: bomb.png
 start_floor: 81
 end_floor: 84
 agro: Sight
+hp: 6972
+attack_damage: 663
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,6 +16,7 @@ vulnerabilities:
   stun: true
   resolution: false
 abilities:
-  - name: 'Self-Destruct'
-    description: 'Enrage - instant big damage AoE'
+  - name: 'Self-destruct'
+    potency: 70% of max HP
+    description: 'instant enrage AoE; used 37 seconds after aggro'
 ---

--- a/_potd_081_enemies/chimera.md
+++ b/_potd_081_enemies/chimera.md
@@ -6,6 +6,9 @@ start_floor: 81
 end_floor: 89
 patrol: true
 agro: Proximity
+hp: 13060
+attack_damage: 1037
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,6 +16,16 @@ vulnerabilities:
   slow: true
   stun: false
   resolution: false
+abilities:
+  - name: 'The Dragon''s Breath'
+    potency: 300
+    description: 'telegraphed conal AoE; inflicts paralysis (15s)'
+  - name: 'The Lion''s Breath'
+    potency: 300
+    description: 'telegraphed conal AoE; inflicts burns (DoT potency 50, 21s)'
+  - name: 'The Ram''s Breath'
+    potency: 300
+    description: 'telegraphed conal AoE; inflicts heavy (10s)'
 notes:
   - 'Can appear on any floor from 81-89, but seems fairly rare in the earlier
     floors, and more common in the later floors'

--- a/_potd_081_enemies/claw.md
+++ b/_potd_081_enemies/claw.md
@@ -6,6 +6,9 @@ family: Scorpion
 start_floor: 85
 end_floor: 89
 agro: Sight
+hp: 7858
+attack_damage: 762
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,4 +16,11 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: 'Inspire (?)'
+    description: 'instant; draws the target in and inflicts prey. Knockback
+    immunity does not work against the draw-in'
+  - name: Impale
+    potency: 130
+    description: 'used against players with prey; clears prey status'
 ---

--- a/_potd_081_enemies/dragon.md
+++ b/_potd_081_enemies/dragon.md
@@ -5,6 +5,9 @@ image: dragon.png
 start_floor: 81
 end_floor: 89
 agro: Sight
+hp: 11732
+attack_damage: 911
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -12,6 +15,11 @@ vulnerabilities:
   slow: true
   stun: false
   resolution: false
+abilities:
+  - name: Fireball
+    potency: 300
+    description: 'telegraphed circle AoE; inflicts burns (DoT potency 50, 15s);
+    also used out of battle'
 notes:
   - 'Can appear on any floor from 81-89, but seems fairly rare in the earlier
     floors, and much more common in the later floors'

--- a/_potd_081_enemies/eruca.md
+++ b/_potd_081_enemies/eruca.md
@@ -6,6 +6,9 @@ family: Crawler
 start_floor: 86
 end_floor: 89
 agro: Sound
+hp: 7968
+attack_damage: 780
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,4 +16,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Incinerate
+    potency: 300
+    description: 'telegraphed conal AoE; inflicts burns (DoT potency 30, 24s)'
 ---

--- a/_potd_081_enemies/gallimimus.md
+++ b/_potd_081_enemies/gallimimus.md
@@ -6,6 +6,9 @@ family: Raptor
 start_floor: 83
 end_floor: 86
 agro: Sight
+hp: 7526
+attack_damage: 721
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -15,5 +18,6 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Flash Evaporation
-    description: 'telegraphed circle AoE; applies Burns (DoT)'
+    potency: 300
+    description: 'telegraphed circle AoE; inflicts burns (DoT potency 100, 9s)'
 ---

--- a/_potd_081_enemies/hapalit.md
+++ b/_potd_081_enemies/hapalit.md
@@ -6,6 +6,9 @@ start_floor: 84
 end_floor: 86
 patrol: true
 agro: Sound
+hp: 7858
+attack_damage: 753
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: false
@@ -13,4 +16,11 @@ vulnerabilities:
   slow: true
   stun: false
   resolution: false
+abilities:
+  - name: Straight Punch
+    potency: 130
+    description: 'instant'
+  - name: 'Elbow Drop (?)'
+    potency: 300
+    description: 'telegraphed backward conal AoE; used when someone is behind'
 ---

--- a/_potd_081_enemies/insentient_inquisitor.md
+++ b/_potd_081_enemies/insentient_inquisitor.md
@@ -5,6 +5,9 @@ image: insentient_inquisitor.png
 start_floor: 81
 end_floor: 89
 agro: Proximity
+hp: 9407
+attack_damage: 922
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_081_enemies/mimic.md
+++ b/_potd_081_enemies/mimic.md
@@ -5,6 +5,9 @@ image: ../mimic.png
 start_floor: 81
 end_floor: 89
 agro: Proximity
+hp: 10625
+attack_damage: 1048
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_081_enemies/necrose_knight.md
+++ b/_potd_081_enemies/necrose_knight.md
@@ -5,6 +5,9 @@ image: necrose_knight.png
 start_floor: 81
 end_floor: 89
 agro: Proximity
+hp: 9961?
+attack_damage: 970?
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_081_enemies/necrose_knight.md
+++ b/_potd_081_enemies/necrose_knight.md
@@ -5,8 +5,8 @@ image: necrose_knight.png
 start_floor: 81
 end_floor: 89
 agro: Proximity
-hp: 9961?
-attack_damage: 970?
+hp: 9961
+attack_damage: 970
 attack_type: Physical
 vulnerabilities:
   bind: false

--- a/_potd_081_enemies/vinegaroon.md
+++ b/_potd_081_enemies/vinegaroon.md
@@ -5,6 +5,9 @@ image: vinegaroon.png
 start_floor: 81
 end_floor: 85
 agro: Sight
+hp: 7194
+attack_damage: 685
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -12,4 +15,12 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Third Leg Forward
+    potency: 300
+    description: 'telegraphed conal AoE'
+  - name: Third Leg Back
+    potency: 300
+    description: 'telegraphed backward conal AoE; inflicts knockback; used
+    after Third Leg Forward if someone is behind'
 ---

--- a/_potd_081_enemies/wamoura.md
+++ b/_potd_081_enemies/wamoura.md
@@ -6,6 +6,9 @@ start_floor: 81
 end_floor: 85
 patrol: true
 agro: Sight
+hp: 7194
+attack_damage: 685
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,4 +16,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Poison Dust
+    potency: 300
+    description: 'telegraphed conal AoE; inflicts poison (DoT potency 60, 15s)'
 ---

--- a/_potd_081_enemies/wamouracampa.md
+++ b/_potd_081_enemies/wamouracampa.md
@@ -5,6 +5,9 @@ image: wamouracampa.png
 start_floor: 81
 end_floor: 85
 agro: Sound
+hp: 7083
+attack_damage: 674
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,4 +15,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Cannonball
+    potency: 130
+    description: 'instant ranged attack'
 ---

--- a/_potd_081_enemies/worm.md
+++ b/_potd_081_enemies/worm.md
@@ -5,6 +5,9 @@ image: worm.png
 start_floor: 84
 end_floor: 88
 agro: Sound
+hp: 7858
+attack_damage: 753
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,6 +15,11 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
-notes:
-  - 'Has an enrage draw-in + pointblank for big damage'
+abilities:
+  - name: 'Sand Cyclone (?)'
+    potency: 90
+    description: 'instant; inflicts sludge (DoT potency 20, 12s)'
+  - name: Sand Breath
+    potency: 300
+    description: 'telegraphed conal AoE; inflicts blind (10s)'
 ---

--- a/_potd_091_enemies/corse.md
+++ b/_potd_091_enemies/corse.md
@@ -5,6 +5,9 @@ image: corse.png
 start_floor: 94
 end_floor: 98
 agro: Proximity
+hp: 10735
+attack_damage: 873
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -12,4 +15,8 @@ vulnerabilities:
   slow: true
   stun: false
   resolution: true
+abilities:
+  - name: Glass Punch
+    potency: 150
+    description: 'instant'
 ---

--- a/_potd_091_enemies/dragon.md
+++ b/_potd_091_enemies/dragon.md
@@ -5,6 +5,9 @@ image: dragon.png
 start_floor: 91
 end_floor: 99
 agro: Sight
+hp: 19036
+attack_damage: 1097
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -12,6 +15,11 @@ vulnerabilities:
   slow: true
   stun: false
   resolution: true
+abilities:
+  - name: Dark Thorn
+    potency: 90
+    description: 'telegraphed circle AoE; also used out of battle, with potency
+    300'
 notes:
   - 'Can appear on any floor from 91-99, but seems fairly rare in the earlier
     floors, and much more common in the later floors'

--- a/_potd_091_enemies/gourmand.md
+++ b/_potd_091_enemies/gourmand.md
@@ -5,6 +5,9 @@ image: gourmand.png
 start_floor: 96
 end_floor: 99
 agro: Proximity
+hp: 11068
+attack_damage: 884
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -13,8 +16,11 @@ vulnerabilities:
   stun: true
   resolution: true
 abilities:
-  - name: 'Beatdown'
-    description: tank buster
+  - name: Beatdown
+    potency: 150
+    description: 'instant'
   - name: 'Dirty Sneeze'
-    description: 'random target damage and stun; not used vs. solo adventurers'
+    potency: 130?
+    description: 'instant; only used against lower-emnity party members (not
+    used against solo adventurers)'
 ---

--- a/_potd_091_enemies/gourmand.md
+++ b/_potd_091_enemies/gourmand.md
@@ -21,6 +21,6 @@ abilities:
     description: 'instant'
   - name: 'Dirty Sneeze'
     potency: 130?
-    description: 'instant; only used against lower-emnity party members (not
+    description: 'instant; only used against lower-enmity party members (not
     used against solo adventurers)'
 ---

--- a/_potd_091_enemies/gravekeeper.md
+++ b/_potd_091_enemies/gravekeeper.md
@@ -6,6 +6,9 @@ start_floor: 97
 end_floor: 99
 patrol: true
 agro: Sound
+hp: 12617
+attack_damage: 908
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -15,7 +18,10 @@ vulnerabilities:
   resolution: true
 abilities:
   - name: Nail in the Coffin
-    description: tank buster
+    potency: 150
+    description: 'instant'
   - name: Vengeance Soul
-    description: '?; not used vs. solo adventurers'
+    potency: 130
+    description: 'instant circle AoE; only used against lower-emnity party
+    members (not used against solo adventurers)'
 ---

--- a/_potd_091_enemies/gravekeeper.md
+++ b/_potd_091_enemies/gravekeeper.md
@@ -22,6 +22,6 @@ abilities:
     description: 'instant'
   - name: Vengeance Soul
     potency: 130
-    description: 'instant circle AoE; only used against lower-emnity party
+    description: 'instant circle AoE; only used against lower-enmity party
     members (not used against solo adventurers)'
 ---

--- a/_potd_091_enemies/hippocerf.md
+++ b/_potd_091_enemies/hippocerf.md
@@ -6,6 +6,9 @@ image: hippocerf.png
 start_floor: 93
 end_floor: 96
 agro: Sight
+hp: 10403
+attack_damage: 866
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,4 +16,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Shriek
+    potency: 200
+    description: 'telegraphed pointblank AoE; inflicts stun (6s)'
 ---

--- a/_potd_091_enemies/iron_corse.md
+++ b/_potd_091_enemies/iron_corse.md
@@ -6,6 +6,9 @@ start_floor: 94
 end_floor: 97
 patrol: true
 agro: Proximity
+hp: 10735
+attack_damage: 873
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,4 +16,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: true
+abilities:
+  - name: Butterfly Float
+    potency: 150
+    description: 'instant gap closer'
 ---

--- a/_potd_091_enemies/knight.md
+++ b/_potd_091_enemies/knight.md
@@ -5,6 +5,9 @@ image: knight.png
 start_floor: 95
 end_floor: 99
 agro: Proximity
+hp: 11068
+attack_damage: 881
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,4 +15,7 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: true
+abilities:
+  - name: Ossify
+    description: 'grants damage up (100%, 8s) to self'
 ---

--- a/_potd_091_enemies/mimic.md
+++ b/_potd_091_enemies/mimic.md
@@ -5,6 +5,9 @@ image: ../mimic.png
 start_floor: 91
 end_floor: 99
 agro: Proximity
+hp: 16380
+attack_damage: 1180
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_091_enemies/mortifying_magnate.md
+++ b/_potd_091_enemies/mortifying_magnate.md
@@ -6,7 +6,7 @@ start_floor: 91
 end_floor: 99
 agro: Proximity
 hp: 12617
-attack_damage: 1017?
+attack_damage: 1017
 attack_type: Physical
 vulnerabilities:
   bind: false

--- a/_potd_091_enemies/mortifying_magnate.md
+++ b/_potd_091_enemies/mortifying_magnate.md
@@ -5,6 +5,9 @@ image: mortifying_magnate.png
 start_floor: 91
 end_floor: 99
 agro: Proximity
+hp: 12617
+attack_damage: 1017?
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_091_enemies/mummy.md
+++ b/_potd_091_enemies/mummy.md
@@ -5,6 +5,9 @@ image: mummy.png
 start_floor: 91
 end_floor: 94
 agro: Proximity
+hp: 9739
+attack_damage: 789
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,4 +15,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: true
+abilities:
+  - name: Rotting Bandages
+    potency: 130
+    description: 'telegraphed conal AoE; inflicts stun (6s)'
 ---

--- a/_potd_091_enemies/roselet.md
+++ b/_potd_091_enemies/roselet.md
@@ -6,6 +6,9 @@ image: roselet.png
 start_floor: 91
 end_floor: 95
 agro: Sound
+hp: 10403
+attack_damage: 878
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,4 +16,11 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Seedvolley
+    potency: 100
+    description: 'instant'
+  - name: Swift Sough
+    potency: 300
+    description: 'telegraphed conal AoE; inflicts knockback'
 ---

--- a/_potd_091_enemies/swarm.md
+++ b/_potd_091_enemies/swarm.md
@@ -5,6 +5,9 @@ image: swarm.png
 start_floor: 91
 end_floor: 94
 agro: Sound
+hp: 9961
+attack_damage: 874
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,4 +15,6 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+notes:
+  - 'Autoattack absorbs 30% of damage dealt'
 ---

--- a/_potd_091_enemies/wraith.md
+++ b/_potd_091_enemies/wraith.md
@@ -6,6 +6,9 @@ start_floor: 91
 end_floor: 93
 patrol: true
 agro: Proximity
+hp: 10403
+attack_damage: 878
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,4 +16,9 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: true
+abilities:
+  - name: Scream
+    potency: 200
+    description: 'huge telegraphed pointblank AoE; inflicts terror (15s); can
+    be interrupted'
 ---

--- a/_potd_101_enemies/beetle.md
+++ b/_potd_101_enemies/beetle.md
@@ -6,6 +6,9 @@ start_floor: 106
 end_floor: 109
 patrol: true
 agro: Proximity
+hp: 13060
+attack_damage: 931
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,4 +16,10 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Rhino Attack
+    potency: 250
+    description: 'gap closer (can be LoSed)'
+  - name: Rhino Guard
+    description: 'grants evasion up (8s) to self'
 ---

--- a/_potd_101_enemies/corrupted_centurion.md
+++ b/_potd_101_enemies/corrupted_centurion.md
@@ -5,6 +5,9 @@ image: centurion.png
 start_floor: 101
 end_floor: 109
 agro: Proximity
+hp: 16823
+attack_damage: 1197
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_101_enemies/doblyn.md
+++ b/_potd_101_enemies/doblyn.md
@@ -5,6 +5,9 @@ image: doblyn.png
 start_floor: 101
 end_floor: 104
 agro: Sight
+hp: 12728
+attack_damage: 915
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,4 +15,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Shatter
+    potency: 300
+    description: 'telegraphed pointblank AoE'
 ---

--- a/_potd_101_enemies/gaelicat.md
+++ b/_potd_101_enemies/gaelicat.md
@@ -5,6 +5,9 @@ image: gaelicat.png
 start_floor: 107
 end_floor: 109
 agro: Sound
+hp: 13060
+attack_damage: 931
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -12,4 +15,11 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Scratch Fever
+    potency: 130
+    description: 'instant'
+  - name: Yowl
+    description: 'telegraphed conal AoE; inflicts physical damage down (90%,
+    15s)'
 ---

--- a/_potd_101_enemies/goblin.md
+++ b/_potd_101_enemies/goblin.md
@@ -6,6 +6,9 @@ start_floor: 103
 end_floor: 106
 patrol: true
 agro: Sight
+hp: 13060
+attack_damage: 925
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,4 +16,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Goblin Rush
+    potency: 50 (x3)
+    description: 'instant 3-hit attack'
 ---

--- a/_potd_101_enemies/hippogryph.md
+++ b/_potd_101_enemies/hippogryph.md
@@ -5,6 +5,9 @@ image: hippogryph.png
 start_floor: 105
 end_floor: 108
 agro: Proximity
+hp: 13060
+attack_damage: 925
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,4 +15,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Shriek
+    potency: 200
+    description: 'telegraphed pointblank AoE; inflicts stun (6s)'
 ---

--- a/_potd_101_enemies/hornet.md
+++ b/_potd_101_enemies/hornet.md
@@ -5,6 +5,9 @@ image: hornet.png
 start_floor: 106
 end_floor: 109
 agro: Proximity
+hp: 13060
+attack_damage: 931
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,6 +17,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Final Sting
-    description: 'Deals 99% max HP damage; used if not killed fast enough;
-    possible to outrange'
+    potency: 99% of max HP
+    description: 'sacrificial enrage; possible to outrange; used at 22-second
+    intervals'
 ---

--- a/_potd_101_enemies/ladybug.md
+++ b/_potd_101_enemies/ladybug.md
@@ -5,6 +5,9 @@ image: ladybug.png
 start_floor: 106
 end_floor: 109
 agro: Sight
+hp: 13060
+attack_damage: 925
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,5 +17,5 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Spoil
-    description: 'inflicts poison'
+    description: 'inflicts poison (DoT potency 20, 15s)'
 ---

--- a/_potd_101_enemies/mimic.md
+++ b/_potd_101_enemies/mimic.md
@@ -5,6 +5,9 @@ image: ../mimic.png
 start_floor: 101
 end_floor: 109
 agro: Proximity
+hp: 17044
+attack_damage: 1211
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_101_enemies/sprite.md
+++ b/_potd_101_enemies/sprite.md
@@ -5,6 +5,10 @@ image: sprite.png
 start_floor: 101
 end_floor: 103
 agro: Sound
+hp: 12728
+attack_damage: 915
+attack_type: Magic
+attack_name: Stone
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_101_enemies/squirrel.md
+++ b/_potd_101_enemies/squirrel.md
@@ -5,6 +5,9 @@ image: squirrel.png
 start_floor: 104
 end_floor: 108
 agro: Sight
+hp: 12949
+attack_damage: 922
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,8 +16,8 @@ vulnerabilities:
   stun: true
   resolution: false
 abilities:
-  - name: 'Scamper'
-    description: 'grants haste'
+  - name: Scamper
+    description: 'grants haste (30s) to self'
 notes:
   - 'Arm''s Length can be used to override the haste buff and prevent it from
   re-applying'

--- a/_potd_101_enemies/stag.md
+++ b/_potd_101_enemies/stag.md
@@ -5,6 +5,9 @@ image: stag.png
 start_floor: 103
 end_floor: 106
 agro: Sight
+hp: 12949
+attack_damage: 922
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,4 +15,8 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Big Horn
+    potency: 130
+    description: 'instant'
 ---

--- a/_potd_101_enemies/yarzon.md
+++ b/_potd_101_enemies/yarzon.md
@@ -5,6 +5,9 @@ image: yarzon.png
 start_floor: 101
 end_floor: 105
 agro: Sound
+hp: 12838
+attack_damage: 917
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,4 +15,7 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: 'Corrosive Spit (?)'
+    description: 'instant; inflicts physical vulnerability up (50%, 20s)'
 ---

--- a/_potd_101_enemies/ziz.md
+++ b/_potd_101_enemies/ziz.md
@@ -6,6 +6,9 @@ start_floor: 101
 end_floor: 104
 patrol: true
 agro: Sight
+hp: 12838
+attack_damage: 917
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,4 +16,7 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Numbing Breath
+    description: 'telegraphed conal AoE; inflicts paralysis (15s)'
 ---

--- a/_potd_111_enemies/bifericeras.md
+++ b/_potd_111_enemies/bifericeras.md
@@ -6,6 +6,9 @@ image: bifericeras.png
 start_floor: 111
 end_floor: 114
 agro: Sight
+hp: 13392
+attack_damage: 941
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,5 +18,6 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Palsynyxis
-    description: 'telegraphed conal AoE'
+    potency: 300
+    description: 'telegraphed conal AoE; inflicts paralysis (15s)'
 ---

--- a/_potd_111_enemies/biloko.md
+++ b/_potd_111_enemies/biloko.md
@@ -6,6 +6,9 @@ start_floor: 116
 end_floor: 119
 patrol: true
 agro: Sight
+hp: 13724
+attack_damage: 958
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -15,5 +18,9 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: The Wood Remembers
+    potency: 300
     description: 'telegraphed conal AoE'
+  - name: Stoneskin
+    description: 'grants stoneskin (10% of max HP, 60s) to a nearby enemy; not
+    used on self'
 ---

--- a/_potd_111_enemies/cobra.md
+++ b/_potd_111_enemies/cobra.md
@@ -6,6 +6,9 @@ start_floor: 114
 end_floor: 117
 patrol: true
 agro: Sight
+hp: 13502
+attack_damage: 943
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -15,7 +18,9 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Regorge
-    description: 'does damage and applies a strong poison'
+    potency: 130
+    description: 'instant; inflicts poison (DoT potency 60, 15s)'
   - name: Devour
+    potency: 100% of max HP
     description: 'instant death; only used if you are a toad'
 ---

--- a/_potd_111_enemies/gigantoad.md
+++ b/_potd_111_enemies/gigantoad.md
@@ -6,6 +6,9 @@ start_floor: 111
 end_floor: 113
 patrol: true
 agro: Sight
+hp: 13392
+attack_damage: 941
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -15,9 +18,12 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Sticky Tongue
-    description: 'draw-in that also stuns if you are looking AWAY; be sure to
-    face towards the toad so you can escape Labored Leap'
+    potency: 50
+    description: 'instant; draws the target in, and inflicts stun (6s) if
+    looking AWAY from the toad - be sure to face toward the toad so you can
+    escape Labored Leap'
   - name: Labored Leap
+    potency: 500
     description: 'telegraphed pointblank AoE; used immediately after Sticky
     Tongue'
 ---

--- a/_potd_111_enemies/leech.md
+++ b/_potd_111_enemies/leech.md
@@ -5,6 +5,9 @@ image: leech.png
 start_floor: 111
 end_floor: 113
 agro: Sight
+hp: 13392
+attack_damage: 941
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: false
@@ -14,5 +17,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Drowning Mist
-    description: 'telegraphed pointblank AoE'
+    potency: 300
+    description: 'telegraphed pointblank AoE; inflicts poison (DoT potency 50,
+    15s)'
 ---

--- a/_potd_111_enemies/mimic.md
+++ b/_potd_111_enemies/mimic.md
@@ -5,6 +5,9 @@ image: ../mimic.png
 start_floor: 111
 end_floor: 119
 agro: Proximity
+hp: 17708
+attack_damage: 1254
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_111_enemies/morbol.md
+++ b/_potd_111_enemies/morbol.md
@@ -5,6 +5,9 @@ image: morbol.png
 start_floor: 117
 end_floor: 119
 agro: Proximity
+hp: 13724
+attack_damage: 958
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -13,11 +16,21 @@ vulnerabilities:
   stun: true
   resolution: false
 abilities:
-  - name: '(Unnamed)'
-    description: 'instant conal AoE applying sleep and slow'
+  - name: 'Sweet Breath (?)'
+    description: 'large instant conal AoE; inflicts sleep (3s) and slow (10s);
+    used immediately before Bad Breath'
   - name: Bad Breath
-    description: 'telegraphed conal AoE; applies several status ailments'
+    description: 'large telegraphed conal AoE; inflicts many debuffs'
 notes:
-  - 'Stand close if solo or tanking, so you''ll be hit by an auto-attack after
-  sleep, and will be able to avoid Bad Breath'
+  - 'Stand close if solo or tanking, so you''ll be able to get out of the Bad
+    Breath AoE after waking up from Sweet Breath'
+  - note: 'Bad Breath inflicts these debuffs:'
+    subnotes:
+      - 'Poison (DoT potency 50, 30s)'
+      - 'Nausea (20s)'
+      - 'Slow (10s)'
+      - 'Blind (30s)'
+      - 'Heavy (20s)'
+      - 'Silence (10s)'
+      - 'Paralysis (30s)'
 ---

--- a/_potd_111_enemies/nanka.md
+++ b/_potd_111_enemies/nanka.md
@@ -5,6 +5,9 @@ image: nanka.png
 start_floor: 115
 end_floor: 118
 agro: Sound
+hp: 13502
+attack_damage: 943
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,5 +17,6 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Brackish Drop
+    potency: 600
     description: 'telegraphed circle AoE; also used out of combat'
 ---

--- a/_potd_111_enemies/ochu.md
+++ b/_potd_111_enemies/ochu.md
@@ -5,6 +5,9 @@ image: ochu.png
 start_floor: 116
 end_floor: 119
 agro: Proximity
+hp: 13613
+attack_damage: 953
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,5 +17,6 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Gold Dust
-    description: 'telegraphed large circle AoE'
+    description: 'telegraphed large circle AoE; inflicts poison (DoT potency
+    60, 15s)'
 ---

--- a/_potd_111_enemies/pudding.md
+++ b/_potd_111_enemies/pudding.md
@@ -5,6 +5,10 @@ image: pudding.png
 start_floor: 111
 end_floor: 115
 agro: Proximity
+hp: 13502
+attack_damage: 941
+attack_name: Stone
+attack_type: Magic
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,5 +18,6 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Amorphic Flail
-    description: tankbuster
+    potency: 130
+    description: 'instant pointblank AoE'
 ---

--- a/_potd_111_enemies/salamander.md
+++ b/_potd_111_enemies/salamander.md
@@ -5,6 +5,9 @@ image: salamander.png
 start_floor: 115
 end_floor: 118
 agro: Sound
+hp: 13613
+attack_damage: 573
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,5 +17,6 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Mucin
-    description: 'grants unbreakable stoneskin; can be interrupted'
+    description: 'grants stoneskin (1/3 of max HP, 8s) to self; can be
+    interrupted'
 ---

--- a/_potd_111_enemies/seedling.md
+++ b/_potd_111_enemies/seedling.md
@@ -5,6 +5,9 @@ image: seedling.png
 start_floor: 117
 end_floor: 119
 agro: Sound
+hp: 13724
+attack_damage: 638
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,7 +15,7 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
-abilities:
-  - name: 'auto-attack'
-    description: 'applies stacking poison'
+notes:
+  - 'Autoattack inflicts stacking poison (DoT potency 10 per stack, max 4
+    stacks, 9s)'
 ---

--- a/_potd_111_enemies/slime.md
+++ b/_potd_111_enemies/slime.md
@@ -5,6 +5,10 @@ image: slime.png
 start_floor: 113
 end_floor: 116
 agro: Sound
+hp: 13502
+attack_damage: 941
+attack_type: Magic
+attack_name: Acid Spray
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,12 +17,12 @@ vulnerabilities:
   stun: true
   resolution: false
 abilities:
-  - name: Acid Spray
-    description: 'applies stacking physical vulnerability up; this is used
-    instead of auto-attacks, but does magical damage, so does not affect its
-    own damage'
   - name: 'Rapture'
-    description: 'Enrage; explodes, doing huge AoE damage; used 37 seconds after pull/agro'
+    potency: 100% of max HP
+    description: 'instant AoE sacrificial enrage'
 notes:
+  - 'Acid Spray inflicts stacking physical vulnerability up (+10% per stack,
+    max 8 stacks, 5s); this ability does magic damage, so its own damage is
+    not affected'
   - 'Can be slowed if transfigured via Pomander of Witching'
 ---

--- a/_potd_111_enemies/slime.md
+++ b/_potd_111_enemies/slime.md
@@ -19,7 +19,8 @@ vulnerabilities:
 abilities:
   - name: 'Rapture'
     potency: 100% of max HP
-    description: 'instant AoE sacrificial enrage'
+    description: 'instant AoE sacrificial enrage; used 37 seconds after
+    pull/aggro'
 notes:
   - 'Acid Spray inflicts stacking physical vulnerability up (+10% per stack,
     max 8 stacks, 5s); this ability does magic damage, so its own damage is

--- a/_potd_121_enemies/adamantoise.md
+++ b/_potd_121_enemies/adamantoise.md
@@ -5,6 +5,9 @@ image: adamantoise.png
 start_floor: 122
 end_floor: 125
 agro: Sight
+hp: 14388
+attack_damage: 986
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -14,5 +17,8 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Tortoise Stomp
-    description: 'telegraphed pointblank AoE'
+    potency: 500
+    description: 'large telegraphed pointblank AoE'
+  - name: 'Strengthen Shell (?)'
+    description: 'grants physical vulnerability down (90%, 20s) to self'
 ---

--- a/_potd_121_enemies/basilisk.md
+++ b/_potd_121_enemies/basilisk.md
@@ -6,6 +6,9 @@ image: basilisk.png
 start_floor: 125
 end_floor: 128
 agro: Sight
+hp: 14388
+attack_damage: 998
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -15,5 +18,9 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Body Slam
+    potency: 300
     description: 'telegraphed pointblank AoE'
+  - name: Stone Gaze
+    description: 'telegraphed conal gaze AoE inflicting petrify (15s) - look
+    away, get behind, or get away'
 ---

--- a/_potd_121_enemies/biast.md
+++ b/_potd_121_enemies/biast.md
@@ -5,6 +5,9 @@ image: biast.png
 start_floor: 121
 end_floor: 124
 agro: Sight
+hp: 14167
+attack_damage: 968
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,9 +17,11 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Levinfang
-    description: 'applies paralyze; has to be close to use this, so ranged DPS
-    can avoid by kiting with Sprint and/or Leg Graze'
+    potency: 130
+    description: 'instant; inflicts paralysis (30s); has to be close to use
+    this, so ranged DPS can avoid by kiting with Sprint and/or Leg Graze'
   - name: Electrify
+    potency: 300
     description: 'telegraphed circle AoE'
 notes:
   - 'Can use Spine Drops to remove paralysis if you''re ok with not using

--- a/_potd_121_enemies/centaur.md
+++ b/_potd_121_enemies/centaur.md
@@ -5,6 +5,9 @@ image: centaur.png
 start_floor: 126
 end_floor: 129
 agro: Proximity
+hp: 14499
+attack_damage: 1010
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,7 +17,8 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Berserk
-    description: 'grants attack bonus'
+    description: 'grants damage up (50%, 20s) to self'
   - name: Rear
+    potency: 300
     description: 'telegraphed pointblank AoE'
 ---

--- a/_potd_121_enemies/dullahan.md
+++ b/_potd_121_enemies/dullahan.md
@@ -6,6 +6,9 @@ start_floor: 121
 end_floor: 123
 patrol: true
 agro: Sound
+hp: 14277
+attack_damage: 976
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -15,5 +18,8 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Iron Justice
+    potency: 300
     description: 'telegraphed conal AoE'
+  - name: 'Suffering Blade (?)'
+    description: 'causes autoattacks to absorb 100% of damage dealt for 30s'
 ---

--- a/_potd_121_enemies/effigy.md
+++ b/_potd_121_enemies/effigy.md
@@ -5,6 +5,9 @@ image: effigy.png
 start_floor: 126
 end_floor: 129
 agro: Sight
+hp: 14499
+attack_damage: 1012
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -14,5 +17,6 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Wild Horn
-    description: 'telegraphed conal AoE with knockback'
+    potency: 200
+    description: 'large telegraphed conal AoE; inflicts knockback'
 ---

--- a/_potd_121_enemies/gangrenous_gigant.md
+++ b/_potd_121_enemies/gangrenous_gigant.md
@@ -5,6 +5,9 @@ image: gangrenous_gigant.png
 start_floor: 121
 end_floor: 129
 agro: Proximity
+hp: 19479
+attack_damage: 1345
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_121_enemies/mimic.md
+++ b/_potd_121_enemies/mimic.md
@@ -5,6 +5,9 @@ image: ../mimic.png
 start_floor: 121
 end_floor: 129
 agro: Proximity
+hp: 19479
+attack_damage: 1345
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_121_enemies/minotaur.md
+++ b/_potd_121_enemies/minotaur.md
@@ -6,6 +6,9 @@ start_floor: 124
 end_floor: 126
 patrol: true
 agro: Sight
+hp: 14499
+attack_damage: 1010
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -14,6 +17,7 @@ vulnerabilities:
   stun: true
   resolution: false
 abilities:
-  - name: 111-Tonze Swing
-    description: 'untelegraphed pointblank AoE with knockback'
+  - name: '111-tonze Swing'
+    potency: 600
+    description: 'untelegraphed pointblank AoE; inflicts knockback'
 ---

--- a/_potd_121_enemies/pteroc.md
+++ b/_potd_121_enemies/pteroc.md
@@ -5,6 +5,9 @@ image: pteroc.png
 start_floor: 121
 end_floor: 123
 agro: Sight
+hp: 13945
+attack_damage: 964
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,5 +17,6 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Tail Chase
+    potency: 300
     description: 'telegraphed pointblank AoE'
 ---

--- a/_potd_121_enemies/sketene.md
+++ b/_potd_121_enemies/sketene.md
@@ -6,6 +6,9 @@ start_floor: 126
 end_floor: 129
 patrol: true
 agro: Sound
+hp: 15052
+attack_damage: 1029
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -15,5 +18,5 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Chirp
-    description: 'untelegraphed large pointblank AoE sleep'
+    description: 'untelegraphed large pointblank AoE; inflicts sleep (15s)'
 ---

--- a/_potd_121_enemies/spriggan.md
+++ b/_potd_121_enemies/spriggan.md
@@ -5,6 +5,10 @@ image: spriggan.png
 start_floor: 121
 end_floor: 125
 agro: Sight
+hp: 14277
+attack_damage: 976
+attack_type: Magic
+attack_name: Blizzard
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,8 +18,10 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: 'Fast Boulder'
-    description: 'telegraphed circle AoE; also casts randomly while out of
-    combat'
+    potency: 300
+    description: 'telegraphed circle AoE; also used out of combat'
+  - name: Haste
+    description: 'grants haste (30s) to self'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'
 ---

--- a/_potd_121_enemies/urolith.md
+++ b/_potd_121_enemies/urolith.md
@@ -5,6 +5,9 @@ image: urolith.png
 start_floor: 127
 end_floor: 129
 agro: Proximity
+hp: 14720
+attack_damage: 1024
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,6 +17,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Tornado
-    description: 'instant circle AoE; can be interrupted, but it''s a very
-    quick cast'
+    potency: 120
+    description: 'untelegraphed circle AoE; can be interrupted, but it''s a
+    very quick cast'
 ---

--- a/_potd_121_enemies/wivre.md
+++ b/_potd_121_enemies/wivre.md
@@ -5,6 +5,9 @@ image: wivre.png
 start_floor: 123
 end_floor: 126
 agro: Proximity
+hp: 14277
+attack_damage: 986
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -14,5 +17,6 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Brow Horn
-    description: tankbuster
+    potency: 130
+    description: 'instant'
 ---

--- a/_potd_131_enemies/ahriman.md
+++ b/_potd_131_enemies/ahriman.md
@@ -6,6 +6,10 @@ start_floor: 131
 end_floor: 139
 patrol: true
 agro: Sight
+hp: 20143
+attack_damage: 1087
+attack_type: Magic
+attack_name: Stone
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +19,8 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Level 5 Petrify
-    description: 'untelegraphed conal AoE; applies petrify - get behind, or get
-    away'
+    description: 'untelegraphed conal AoE inflicting petrify (15s) - get behind
+    or get away'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'
 ---

--- a/_potd_131_enemies/catoblepas.md
+++ b/_potd_131_enemies/catoblepas.md
@@ -6,6 +6,9 @@ start_floor: 135
 end_floor: 137
 patrol: true
 agro: Sight
+hp: 16491
+attack_damage: 1081
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -14,9 +17,10 @@ vulnerabilities:
   stun: true
   resolution: false
 abilities:
-  - name: '?'
-    description: 'telegraphed conal gaze AoE - look away, get behind, or get
-    away'
+  - name: Eye of the Stunted
+    description: 'telegraphed conal gaze AoE inflicting minimum (30s) - look
+    away, get behind, or get away'
   - name: 'Jettatura'
+    potency: 300
     description: 'telegraphed circle AoE'
 ---

--- a/_potd_131_enemies/dahak.md
+++ b/_potd_131_enemies/dahak.md
@@ -5,6 +5,9 @@ image: dahak.png
 start_floor: 135
 end_floor: 138
 agro: Sight
+hp: 16491
+attack_damage: 1081
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,6 +16,11 @@ vulnerabilities:
   stun: true
   resolution: false
 abilities:
-  - name: '?'
-    description: 'applies heavy'
+  - name: 'Rotten Breath (?)'
+    potency: 120
+    description: 'inflicts disease (30s)'
+  - name: 'Tail Drive (?)'
+    potency: 300
+    description: 'telegraphed backward conal AoE inflicting concussion (DoT
+    potency 30, 15s); used if someone is behind'
 ---

--- a/_potd_131_enemies/gourmand.md
+++ b/_potd_131_enemies/gourmand.md
@@ -6,6 +6,9 @@ start_floor: 131
 end_floor: 134
 patrol: true
 agro: Proximity
+hp: 15937
+attack_damage: 1058
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -14,6 +17,7 @@ vulnerabilities:
   stun: true
   resolution: true
 abilities:
-  - name: 'Beatdown(?)'
-    description: 'tankbuster'
+  - name: Beatdown
+    potency: 130
+    description: 'instant'
 ---

--- a/_potd_131_enemies/guard.md
+++ b/_potd_131_enemies/guard.md
@@ -5,6 +5,9 @@ image: guard.png
 start_floor: 134
 end_floor: 138
 agro: Sight
+hp: 16159
+attack_damage: 1074
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -12,4 +15,11 @@ vulnerabilities:
   slow: true
   stun: false
   resolution: false
+abilities:
+  - name: Void Slash
+    potency: 100
+    description: 'instant'
+  - name: Void Trap
+    potency: 300
+    description: 'telegraphed circle AoE'
 ---

--- a/_potd_131_enemies/half-cracked_captain.md
+++ b/_potd_131_enemies/half-cracked_captain.md
@@ -6,7 +6,7 @@ start_floor: 131
 end_floor: 139
 agro: Proximity
 hp: 22025
-attack_damage: 1454?
+attack_damage: 1454
 attack_type: Physical
 vulnerabilities:
   bind: false

--- a/_potd_131_enemies/half-cracked_captain.md
+++ b/_potd_131_enemies/half-cracked_captain.md
@@ -5,6 +5,9 @@ image: captain.png
 start_floor: 131
 end_floor: 139
 agro: Proximity
+hp: 22025
+attack_damage: 1454?
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_131_enemies/hecteyes.md
+++ b/_potd_131_enemies/hecteyes.md
@@ -5,6 +5,9 @@ image: hecteyes.png
 start_floor: 131
 end_floor: 135
 agro: Sound
+hp: 15605
+attack_damage: 1046
+attack_type: Magic
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,8 +16,9 @@ vulnerabilities:
   stun: true
   resolution: false
 abilities:
-  - name: '?'
-    description: 'telegraphed pointblank AoE; applies paralyze'
+  - name: Hex Eye
+    potency: 200
+    description: 'telegraphed pointblank AoE'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'
 ---

--- a/_potd_131_enemies/hecteyes.md
+++ b/_potd_131_enemies/hecteyes.md
@@ -18,7 +18,7 @@ vulnerabilities:
 abilities:
   - name: Hex Eye
     potency: 200
-    description: 'telegraphed pointblank AoE'
+    description: 'telegraphed pointblank AoE; inflicts paralysis (15s)'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'
 ---

--- a/_potd_131_enemies/mimic.md
+++ b/_potd_131_enemies/mimic.md
@@ -5,6 +5,9 @@ image: ../mimic.png
 start_floor: 131
 end_floor: 139
 agro: Proximity
+hp: 22025
+attack_damage: 1454
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_131_enemies/monk.md
+++ b/_potd_131_enemies/monk.md
@@ -6,6 +6,10 @@ image: monk.png
 start_floor: 136
 end_floor: 139
 agro: Proximity
+hp: 16602
+attack_damage: 1091
+attack_type: Magic
+attack_name: Water
 vulnerabilities:
   bind: false
   heavy: true
@@ -14,10 +18,11 @@ vulnerabilities:
   stun: true
   resolution: false
 abilities:
-  - name: '?'
-    description: 'draw-in'
-  - name: 'Flood'
-    description: 'telegraphed pointblank AoE; used imediately after draw-in'
+  - name: Sucker
+    description: 'large untelegraphed pointblank AoE; draws players in'
+  - name: Flood
+    potency: 350
+    description: 'telegraphed pointblank AoE; used immediately after Sucker'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'
 ---

--- a/_potd_131_enemies/mummy.md
+++ b/_potd_131_enemies/mummy.md
@@ -5,6 +5,9 @@ image: mummy.png
 start_floor: 133
 end_floor: 136
 agro: Proximity
+hp: 16159
+attack_damage: 1069
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,6 +16,7 @@ vulnerabilities:
   stun: true
   resolution: true
 abilities:
-  - name: 'Rotting Bandages'
-    description: 'telegraphed conal AoE'
+  - name: Rotting Bandages
+    potency: 130
+    description: 'telegraphed conal AoE; inflicts stun (6s)'
 ---

--- a/_potd_131_enemies/ogre.md
+++ b/_potd_131_enemies/ogre.md
@@ -5,6 +5,9 @@ image: ogre.png
 start_floor: 131
 end_floor: 135
 agro: Sight
+hp: 15397
+attack_damage: 1058
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,6 +16,7 @@ vulnerabilities:
   stun: false
   resolution: false
 abilities:
-  - name: 'Heartburn'
-    description: 'telegraphed circle AoE'
+  - name: Heartburn
+    potency: 300
+    description: 'large telegraphed circle AoE'
 ---

--- a/_potd_131_enemies/soul.md
+++ b/_potd_131_enemies/soul.md
@@ -6,6 +6,9 @@ image: soul.png
 start_floor: 131
 end_floor: 133
 agro: Sound
+hp: 15495
+attack_damage: 1041
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,6 +17,7 @@ vulnerabilities:
   stun: true
   resolution: true
 abilities:
-  - name: '?'
-    description: 'telegraphed pointblank AoE'
+  - name: Curse
+    potency: 200
+    description: 'telegraphed pointblank AoE; also deals 500 MP damage'
 ---

--- a/_potd_131_enemies/taurus.md
+++ b/_potd_131_enemies/taurus.md
@@ -5,6 +5,9 @@ image: taurus.png
 start_floor: 137
 end_floor: 139
 agro: Sight
+hp: 17044
+attack_damage: 1107
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,6 +16,9 @@ vulnerabilities:
   stun: true
   resolution: false
 abilities:
+  - name: Triclip
+    potency: 120
+    description: 'instant'
   - name: Voidblood
     description: 'telegraphed circle AoE that inflicts Voidblood (increases
     damage taken); not used vs. solo adventurers'

--- a/_potd_131_enemies/troubador.md
+++ b/_potd_131_enemies/troubador.md
@@ -5,6 +5,10 @@ image: troubador.png
 start_floor: 136
 end_floor: 139
 agro: Proximity
+hp: 16824
+attack_damage: 1099
+attack_type: Magic
+attack_name: Dark
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_141_enemies/bhoot.md
+++ b/_potd_141_enemies/bhoot.md
@@ -5,6 +5,9 @@ image: bhoot.png
 start_floor: 143
 end_floor: 146
 agro: Sound
+hp: 17708
+attack_damage: 1161
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,7 +17,8 @@ vulnerabilities:
   resolution: true
 abilities:
   - name: 'Paralyze III'
-    description: 'applies paralyze. Can be interrupted'
+    description: 'huge untelegraphed pointblank AoE inflicting paralysis (15s);
+    can be interrupted'
 job_specifics:
   MCH:
     difficulty: Easy

--- a/_potd_141_enemies/demon.md
+++ b/_potd_141_enemies/demon.md
@@ -18,7 +18,7 @@ vulnerabilities:
 abilities:
   - name: Dark Dome
     potency: 90
-    description: 'tankbuster'
+    description: 'instant'
   - name: Charybdis
     potency: 90% of current HP
     description: 'enrage; can be interrupted'

--- a/_potd_141_enemies/demon.md
+++ b/_potd_141_enemies/demon.md
@@ -5,6 +5,9 @@ image: demon.png
 start_floor: 141
 end_floor: 143
 agro: Sight
+hp: 17266
+attack_damage: 1132
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,11 +17,11 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Dark Dome
+    potency: 90
     description: 'tankbuster'
   - name: Charybdis
-    description: 'instant big damage (enrage)'
-notes:
-  - 'Hits pretty hard'
+    potency: 90% of current HP
+    description: 'enrage; can be interrupted'
 job_specifics:
   MCH:
     difficulty: Medium

--- a/_potd_141_enemies/dragon.md
+++ b/_potd_141_enemies/dragon.md
@@ -5,6 +5,9 @@ image: dragon.png
 start_floor: 147
 end_floor: 149
 agro: Sight
+hp: 18926
+attack_damage: 1201
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,9 +17,12 @@ vulnerabilities:
   resolution: true
 abilities:
   - name: Evil Eye
-    description: conal gaze AoE - look away, get behind, or get away
+    potency: 300
+    description: conal gaze AoE inflicting terror (5s) - look away, get behind,
+    or get away
   - name: Miasma Breath
-    description: telegraphed conal AoE causing damage and disease
+    potency: 300
+    description: telegraphed conal AoE; inflicts disease (15s)
 job_specifics:
   MCH:
     difficulty: Easy

--- a/_potd_141_enemies/dragon.md
+++ b/_potd_141_enemies/dragon.md
@@ -18,11 +18,11 @@ vulnerabilities:
 abilities:
   - name: Evil Eye
     potency: 300
-    description: conal gaze AoE inflicting terror (5s) - look away, get behind,
-    or get away
+    description: 'conal gaze AoE inflicting terror (5s) - look away, get
+    behind, or get away'
   - name: Miasma Breath
     potency: 300
-    description: telegraphed conal AoE; inflicts disease (15s)
+    description: 'telegraphed conal AoE; inflicts disease (15s)'
 job_specifics:
   MCH:
     difficulty: Easy

--- a/_potd_141_enemies/gargoyle.md
+++ b/_potd_141_enemies/gargoyle.md
@@ -21,7 +21,7 @@ abilities:
     description: 'instant; inflicts poison (DoT potency 55, 20s)'
   - name: Grim Fate
     potency: 130
-    description: 'tankbuster'
+    description: 'instant'
 notes:
   - 'Hits pretty hard - watch out for poison damage'
 job_specifics:

--- a/_potd_141_enemies/gargoyle.md
+++ b/_potd_141_enemies/gargoyle.md
@@ -5,6 +5,9 @@ image: gargoyle.png
 start_floor: 141
 end_floor: 145
 agro: Sight
+hp: 17266
+attack_damage: 1145
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,11 +17,13 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Corrupted Tail
-    description: 'applies poison'
+    potency: 100
+    description: 'instant; inflicts poison (DoT potency 55, 20s)'
   - name: Grim Fate
+    potency: 130
     description: 'tankbuster'
 notes:
-  - 'Hits pretty hard'
+  - 'Hits pretty hard - watch out for poison damage'
 job_specifics:
   MCH:
     difficulty: Medium

--- a/_potd_141_enemies/hellhound.md
+++ b/_potd_141_enemies/hellhound.md
@@ -5,6 +5,9 @@ image: hellhound.png
 start_floor: 145
 end_floor: 148
 agro: Sight
+hp: 18151
+attack_damage: 1173
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -12,6 +15,10 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Ravenous Bite
+    potency: 110
+    description: 'instant'
 job_specifics:
   MCH:
     difficulty: Medium

--- a/_potd_141_enemies/ked.md
+++ b/_potd_141_enemies/ked.md
@@ -6,6 +6,9 @@ family: Gnat
 start_floor: 141
 end_floor: 143
 agro: Sight
+hp: 17155
+attack_damage: 1120
+attack_type: Magic
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,6 +18,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Thunderstrike
+    potency: 300
     description: 'telegraphed line AoE'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'

--- a/_potd_141_enemies/keeper.md
+++ b/_potd_141_enemies/keeper.md
@@ -6,6 +6,9 @@ start_floor: 147
 end_floor: 149
 patrol: true
 agro: Sound
+hp: 18926
+attack_damage: 1201
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,8 +16,10 @@ vulnerabilities:
   slow: true
   stun: false
   resolution: true
-notes:
-  - 'Hits pretty hard'
+abilities:
+  - name: Nail in the Coffin
+    potency: 150
+    description: 'instant'
 job_specifics:
   MCH:
     difficulty: Medium

--- a/_potd_141_enemies/knight.md
+++ b/_potd_141_enemies/knight.md
@@ -5,6 +5,9 @@ image: knight.png
 start_floor: 142
 end_floor: 146
 agro: Proximity
+hp: 17487
+attack_damage: 1155
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,8 +15,14 @@ vulnerabilities:
   slow: true
   stun: unknown
   resolution: true
+abilities:
+  - name: Skullsplinter
+    potency: 130
+    description: 'instant'
+  - name: Ossify
+    description: 'grants damage up (100%, 8s) to self'
 notes:
-  - 'Hits pretty hard'
+  - 'Hits pretty hard with the attack bonus'
 job_specifics:
   MCH:
     difficulty: Medium

--- a/_potd_141_enemies/manticore.md
+++ b/_potd_141_enemies/manticore.md
@@ -6,6 +6,9 @@ start_floor: 141
 end_floor: 143
 patrol: true
 agro: Sight
+hp: 17266
+attack_damage: 1219
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -15,11 +18,17 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Wild Charge
-    description: 'charge attack used . Gains an attack bonus immediately
-    afterwards'
+    potency: 130
+    description: 'instant gap closer'
+  - name: 'Enrage (?)'
+    description: 'grants damage up (50%, 30s) to self; used immediately after
+    Wild Charge. When the buff expires, it changes to a physical damage down
+    debuff (60%, 30s)'
   - name: Ripper Claw
-    description: 'untelegraphed cone AoE - don''t stand in front!'
-  - name: 'Fireball'
+    potency: 300
+    description: 'untelegraphed conal AoE - don't stand in front!'
+  - name: Fireball
+    potency: 300
     description: 'telegraphed circle AoE'
 notes:
   - 'Hits pretty hard with the attack bonus'

--- a/_potd_141_enemies/manticore.md
+++ b/_potd_141_enemies/manticore.md
@@ -26,7 +26,7 @@ abilities:
     debuff (60%, 30s)'
   - name: Ripper Claw
     potency: 300
-    description: 'untelegraphed conal AoE - don't stand in front!'
+    description: 'untelegraphed conal AoE - don''t stand in front!'
   - name: Fireball
     potency: 300
     description: 'telegraphed circle AoE'

--- a/_potd_141_enemies/mimic.md
+++ b/_potd_141_enemies/mimic.md
@@ -5,6 +5,9 @@ image: ../mimic.png
 start_floor: 141
 end_floor: 149
 agro: Proximity
+hp: 24570
+attack_damage: 1562
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_141_enemies/persona.md
+++ b/_potd_141_enemies/persona.md
@@ -5,6 +5,9 @@ image: persona.png
 start_floor: 146
 end_floor: 149
 agro: Proximity
+hp: 18483
+attack_damage: 1177
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,8 +16,9 @@ vulnerabilities:
   stun: true
   resolution: true
 abilities:
-  - name: Paralyze III
-    description: 'applies paralyze. Can be interrupted'
+  - name: 'Paralyze III'
+    description: 'huge untelegraphed pointblank AoE inflicting paralysis (15s);
+    can be interrupted'
 job_specifics:
   MCH:
     difficulty: Easy

--- a/_potd_141_enemies/succubus.md
+++ b/_potd_141_enemies/succubus.md
@@ -5,6 +5,9 @@ image: succubus.png
 start_floor: 146
 end_floor: 149
 agro: Sight
+hp: 18594
+attack_damage: 1189
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -12,6 +15,14 @@ vulnerabilities:
   slow: true
   stun: true
   resolution: false
+abilities:
+  - name: Dark Mist
+    potency: 300
+    description: 'large telegraphed pointblank AoE; inflicts terror (10s)'
+  - name: Void Fire IV
+    potency: 350
+    description: 'large telegraphed circle AoE; used immediately after Dark
+    Mist; also used out of battle'
 job_specifics:
   MCH:
     difficulty: Easy

--- a/_potd_141_enemies/wraith.md
+++ b/_potd_141_enemies/wraith.md
@@ -6,6 +6,9 @@ start_floor: 144
 end_floor: 146
 patrol: true
 agro: Proximity
+hp: 18151
+attack_damage: 1173
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,7 +18,9 @@ vulnerabilities:
   resolution: true
 abilities:
   - name: Scream
-    description: 'huge telegraphed pointblank AoE; applies terror; can be interrupted'
+    potency: 200
+    description: 'huge telegraphed pointblank AoE; inflicts terror (10s); can
+    be interrupted'
 job_specifics:
   MCH:
     difficulty: Easy

--- a/_potd_151_enemies/abaia.md
+++ b/_potd_151_enemies/abaia.md
@@ -21,7 +21,7 @@ abilities:
     description: 'telegraphed circle AoE; also used out of combat'
   - name: 'Resonate (?)'
     description: 'grants physical damage up (80%, 30s) to self; used 47 seconds
-    after aggro'
+    after pull/aggro'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_151_enemies/abaia.md
+++ b/_potd_151_enemies/abaia.md
@@ -6,6 +6,9 @@ family: Vodoriga
 start_floor: 154
 end_floor: 158
 agro: Sight
+hp: 21250
+attack_damage: 1444
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,7 +18,10 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Terror Eye
-    description: telegraphed circle AoE. Also used out of combat'
+    description: 'telegraphed circle AoE; also used out of combat'
+  - name: 'Resonate (?)'
+    description: 'grants physical damage up (80%, 30s) to self; used 47 seconds
+    after aggro'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_151_enemies/arch_demon.md
+++ b/_potd_151_enemies/arch_demon.md
@@ -6,6 +6,9 @@ start_floor: 157
 end_floor: 159
 patrol: true
 agro: Proximity
+hp: 22578
+attack_damage: 1584
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,10 +18,12 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Abyssal Swing
+    potency: 300
     description: 'telegraphed conal AoE. Try to stay very near or far when
     paralyzed, so you don''t get caught in the middle of this'
   - name: Abyssal Transfixion
-    description: applies paralyze
+    potency: 130
+    description: 'instant; inflicts paralysis (30s)'
 notes:
   - 'If there are several, you may want to pull them in quick succession to
     take advantage of diminishing returns on paralyze'

--- a/_potd_151_enemies/deepeye.md
+++ b/_potd_151_enemies/deepeye.md
@@ -5,6 +5,9 @@ image: deepeye.png
 start_floor: 151
 end_floor: 155
 agro: Sight
+hp: 19811
+attack_damage: 1293
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,9 +17,10 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Optical Intrusion
-    description: fairly weak attack (cleave?)
+    potency: 130
+    description: 'instant'
   - name: Hypnotize
-    description: 'roomwide gaze sleep - look away'
+    description: 'roomwide gaze attack inflicting paralysis (30s) - look away'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_151_enemies/devilet.md
+++ b/_potd_151_enemies/devilet.md
@@ -6,6 +6,10 @@ image: devilet.png
 start_floor: 155
 end_floor: 159
 agro: Sight
+hp: 21693
+attack_damage: 1491
+attack_type: Magic
+attack_name: Blizzard
 vulnerabilities:
   bind: true
   heavy: true
@@ -15,12 +19,13 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Ice Spikes
-    description: 'Causes you to take significant damage whenever you hit the
-    enemy; can be interrupted. Recommended to interrupt or disengage
-    immediately. The damage can kill you very quickly'
+    description: 'Grants counterattack (potency 200, 5s) to self; can be
+    interrupted. Recommended to interrupt or disengage immediately. The damage
+    can kill you very quickly'
   - name: Void Blizzard
-    description: 'Does damage and applies slow; can be interrupted. It only has
-    medium range, so you can also run away to avoid it'
+    potency: 130
+    description: 'Inflicts slow (20s); can be interrupted. It only has medium
+    range, so you can also run away to avoid it'
 notes:
   - 'Disengaging during Ice Spikes and running away to avoid Void Blizzard is
     probably the safest option as you avoid all damage'

--- a/_potd_151_enemies/gremlin.md
+++ b/_potd_151_enemies/gremlin.md
@@ -5,6 +5,9 @@ image: gremlin.png
 start_floor: 151
 end_floor: 155
 agro: Sight
+hp: 20254
+attack_damage: 1342
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,9 +17,10 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Bad Mouth
-    description: 'applies vulnerability up'
+    description: 'instant; inflicts vulnerability up (25%, 10s)'
   - name: Fire II
-    description: 'telegraphed circle AoE. Can be interrupted'
+    potency: 300
+    description: 'telegraphed circle AoE'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_151_enemies/marolith.md
+++ b/_potd_151_enemies/marolith.md
@@ -19,7 +19,7 @@ vulnerabilities:
 abilities:
   - name: Carpomission
     potency: 130
-    description: tankbuster
+    description: 'instant'
   - name: Isle Drop
     potency: 300
     description: 'telegraphed circle AoE; inflicts stun (5s)'

--- a/_potd_151_enemies/marolith.md
+++ b/_potd_151_enemies/marolith.md
@@ -6,6 +6,9 @@ start_floor: 154
 end_floor: 157
 patrol: true
 agro: Proximity
+hp: 21693
+attack_damage: 1491
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,9 +18,11 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Carpomission
+    potency: 130
     description: tankbuster
   - name: Isle Drop
-    description: 'telegraphed circle AoE'
+    potency: 300
+    description: 'telegraphed circle AoE; inflicts stun (5s)'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_151_enemies/mimic.md
+++ b/_potd_151_enemies/mimic.md
@@ -5,6 +5,9 @@ image: ../mimic.png
 start_floor: 151
 end_floor: 159
 agro: Proximity
+hp: 29440
+attack_damage: 2070
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_151_enemies/pot.md
+++ b/_potd_151_enemies/pot.md
@@ -21,7 +21,7 @@ abilities:
     description: 'roomwide gaze attack inflicting blind (15s) - look away'
   - name: Double Ray
     potency: 120
-    description: 'tankbuster'
+    description: 'instant'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_151_enemies/pot.md
+++ b/_potd_151_enemies/pot.md
@@ -5,6 +5,9 @@ image: pot.png
 start_floor: 153
 end_floor: 156
 agro: Proximity
+hp: 20697
+attack_damage: 1393
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,8 +17,10 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Mysterious Light
-    description: 'roomwide gaze attack that blinds'
+    potency: 400
+    description: 'roomwide gaze attack inflicting blind (15s) - look away'
   - name: Double Ray
+    potency: 120
     description: 'tankbuster'
 job_specifics:
   GNB:

--- a/_potd_151_enemies/pudding.md
+++ b/_potd_151_enemies/pudding.md
@@ -6,6 +6,10 @@ family: Flan
 start_floor: 151
 end_floor: 154
 agro: Proximity
+hp: 19258
+attack_damage: 1243
+attack_type: Magic
+attack_name: Water
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,7 +19,8 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Amorphic Flail
-    description: 'tankbuster (melee)'
+    potency: 130
+    description: 'instant pointblank AoE'
 notes:
   - 'Caster, but also does melee attacks if you''re close. Keeping distance
     will mitigate some damage'

--- a/_potd_151_enemies/shabti.md
+++ b/_potd_151_enemies/shabti.md
@@ -7,6 +7,9 @@ start_floor: 151
 end_floor: 153
 patrol: true
 agro: Sight
+hp: 20254
+attack_damage: 1208
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -16,6 +19,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: 'Death''s Door'
+    potency: 400
     description: 'quick, long, narrow line AoE. It will spam this every few
     seconds'
 job_specifics:

--- a/_potd_151_enemies/soulflayer.md
+++ b/_potd_151_enemies/soulflayer.md
@@ -5,6 +5,9 @@ image: soulflayer.png
 start_floor: 156
 end_floor: 159
 agro: Sight
+hp: 22578
+attack_damage: 1584
+attack_type: Magic
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,9 +17,11 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Mind Blast
-    description: 'telegraphed pointblank AoE'
+    potency: 300
+    description: 'telegraphed pointblank AoE; inflicts paralysis (15s)'
   - name: Drain Touch
-    description: 'drains HP'
+    potency: 130
+    description: 'instant; absorbs 100% of damage dealt'
 notes:
   - Caster - kiting doesn't help to mitigate damage
   - 'Can be slowed if transfigured via Pomander of Witching'

--- a/_potd_151_enemies/sunken_captain.md
+++ b/_potd_151_enemies/sunken_captain.md
@@ -5,6 +5,9 @@ image: captain.png
 start_floor: 151
 end_floor: 159
 agro: Proximity
+hp: 29440
+attack_damage: 2070
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_151_enemies/taurus.md
+++ b/_potd_151_enemies/taurus.md
@@ -5,6 +5,9 @@ image: taurus.png
 start_floor: 156
 end_floor: 159
 agro: Sight
+hp: 22136
+attack_damage: 1540
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,7 +17,9 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Frightful Roar
-    description: 'telegraphed pointblank AoE'
+    potency: 300
+    description: 'telegraphed pointblank AoE; inflicts vulnerability up (20%,
+    30s)'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_161_enemies/archaeosaur.md
+++ b/_potd_161_enemies/archaeosaur.md
@@ -18,7 +18,7 @@ vulnerabilities:
 abilities:
   - name: Underbite
     potency: 130
-    description: 'tankbuster'
+    description: 'instant'
   - name: Primordial Bark
     description: 'telegraphed pointblank AoE'
 notes:

--- a/_potd_161_enemies/archaeosaur.md
+++ b/_potd_161_enemies/archaeosaur.md
@@ -5,6 +5,9 @@ image: archaeosaur.png
 start_floor: 165
 end_floor: 169
 agro: Sight
+hp: 23796
+attack_damage: 1877
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -14,7 +17,8 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Underbite
-    description: tankbuster
+    potency: 130
+    description: 'tankbuster'
   - name: Primordial Bark
     description: 'telegraphed pointblank AoE'
 notes:

--- a/_potd_161_enemies/croc.md
+++ b/_potd_161_enemies/croc.md
@@ -5,6 +5,9 @@ image: croc.png
 start_floor: 161
 end_floor: 165
 agro: Sight
+hp: 21914
+attack_damage: 1687
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,7 +17,8 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Crushing Fangs
-    description: 'tankbuster (cleave?)'
+    potency: 130
+    description: 'instant'
 notes:
   - Hits pretty hard
   - 'Doesn''t stop to use any abilities, so the damage is constant'

--- a/_potd_161_enemies/diplocaulus.md
+++ b/_potd_161_enemies/diplocaulus.md
@@ -6,6 +6,9 @@ image: diplocaulus.png
 start_floor: 166
 end_floor: 169
 agro: Proximity
+hp: 24238
+attack_damage: 1924
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -15,8 +18,8 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Mucin
-    description: 'grants Stoneskin that can''t be broken for a few seconds. Can
-    be interrupted'
+    description: 'grants stoneskin (1/3 of max HP, 8s) to self; can be
+    interrupted'
   - name: Foregone Gleam
     description: 'untelegraphed conal gaze AoE - look away, get behind, or get
     away'

--- a/_potd_161_enemies/flyblown_praefectus.md
+++ b/_potd_161_enemies/flyblown_praefectus.md
@@ -5,6 +5,9 @@ image: flyblown_praefectus.png
 start_floor: 161
 end_floor: 169
 agro: Proximity
+hp: 32207
+attack_damage: 2572
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_161_enemies/lindwurm.md
+++ b/_potd_161_enemies/lindwurm.md
@@ -6,6 +6,9 @@ image: lindwurm.png
 start_floor: 161
 end_floor: 164
 agro: Sight
+hp: 21361
+attack_damage: 1635
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -15,7 +18,8 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Foul Breath
-    description: 'telegraphed conal AoE'
+    potency: 300
+    description: 'telegraphed conal AoE; inflicts burns (DoT potency 30, 12s)'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_161_enemies/mimic.md
+++ b/_potd_161_enemies/mimic.md
@@ -5,6 +5,9 @@ image: ../mimic.png
 start_floor: 161
 end_floor: 169
 agro: Proximity
+hp: 32207
+attack_damage: 2572
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_161_enemies/mylodon.md
+++ b/_potd_161_enemies/mylodon.md
@@ -5,6 +5,9 @@ image: mylodon.png
 start_floor: 164
 end_floor: 168
 agro: Sight
+hp: 23242
+attack_damage: 1828
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,6 +17,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Slowball
+    potency: 130
     description: 'instant circle AoE'
   - name: Snow Flurry
     description: 'telegraphed conal AoE'

--- a/_potd_161_enemies/pteranodon.md
+++ b/_potd_161_enemies/pteranodon.md
@@ -6,6 +6,9 @@ start_floor: 166
 end_floor: 169
 patrol: true
 agro: Proximity
+hp: 24681
+attack_damage: 1975
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -15,6 +18,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Lightning Bolt
+    potency: 300
     description: 'telegraphed circle AoE'
 job_specifics:
   GNB:

--- a/_potd_161_enemies/sarcosuchus.md
+++ b/_potd_161_enemies/sarcosuchus.md
@@ -5,6 +5,9 @@ image: sarcosuchus.png
 start_floor: 161
 end_floor: 165
 agro: Sight
+hp: 22357
+attack_damage: 1735
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,6 +17,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Critical Bite
+    potency: 300
     description: 'telegraphed conal AoE'
 job_specifics:
   GNB:

--- a/_potd_161_enemies/triceratops.md
+++ b/_potd_161_enemies/triceratops.md
@@ -5,6 +5,9 @@ image: triceratops.png
 start_floor: 166
 end_floor: 169
 agro: Proximity
+hp: 24681
+attack_damage: 1975
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -14,7 +17,8 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Batterhorn
-    description: tankbuster
+    potency: 130
+    description: 'instant'
 notes:
   - Hits pretty hard
 job_specifics:

--- a/_potd_161_enemies/tursus.md
+++ b/_potd_161_enemies/tursus.md
@@ -6,6 +6,9 @@ start_floor: 161
 end_floor: 163
 patrol: true
 agro: Sight
+hp: 21914
+attack_damage: 1687
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,9 +18,11 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Chilling Cyclone
-    description: 'telegraphed conal AoE'
+    description: 'telegraphed conal AoE; inflicts deep freeze (DoT potency 50,
+    9s)'
   - name: Ice Dispenser
-    description: 'instant circle AoE that applies slow'
+    potency: 130
+    description: 'instant circle AoE; inflicts slow (15s)'
 notes:
   - 'If there are several, you may want to pull them in quick succession to
     take advantage of diminishing returns on slow'

--- a/_potd_161_enemies/vinegaroon.md
+++ b/_potd_161_enemies/vinegaroon.md
@@ -6,6 +6,9 @@ start_floor: 164
 end_floor: 166
 patrol: true
 agro: Sight
+hp: 23242
+attack_damage: 1828
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,11 +18,13 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Third Leg Forward
-    description: telegraphed conal AoE
+    potency: 300?
+    description: 'telegraphed conal AoE'
   - name: Third Leg Back
-    description: 'telegraphed conal AoE behind. Used right after Third Leg
-    Forward if there is someone behind, and will use it over and over as long
-    as someone is behind it.'
+    potency: 300?
+    description: 'telegraphed backward conal AoE; inflicts knockback. Used
+    after Third Leg Forward if someone is behind, and will use it over and
+    over as long as someone is behind it.'
 notes:
   - 'Bait Third Leg Back repeatedly to avoid taking any damage - just keep
     running in and out of its area'

--- a/_potd_161_enemies/wivre.md
+++ b/_potd_161_enemies/wivre.md
@@ -5,6 +5,9 @@ image: wivre.png
 start_floor: 163
 end_floor: 166
 agro: Proximity
+hp: 22800
+attack_damage: 1784
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -14,7 +17,8 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Brow Horn
-    description: tankbuster
+    potency: 130
+    description: 'instant'
 notes:
   - Hits pretty hard
   - 'Doesn''t stop to use any abilities, so the damage is constant'

--- a/_potd_171_enemies/anzu.md
+++ b/_potd_171_enemies/anzu.md
@@ -5,6 +5,9 @@ image: anzu.png
 start_floor: 176
 end_floor: 179
 agro: Sight
+hp: 26784
+attack_damage: 2364
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,10 +16,12 @@ vulnerabilities:
   stun: true
   resolution: false
 abilities:
-  - name: '?'
-    description: applies windburn (DoT)
+  - name: 'Sonic Boom (?)'
+    description: 'instant; inflicts windburn (DoT potency 15, 20s)'
   - name: Flying Frenzy
-    description: 'instant big damage gap-closer circle AoE that applies stun'
+    potency: 180
+    description: 'instant circle AoE gap closer; inflicts stun (2s) and
+    vulnerability up (50%, 10s)'
 notes:
   - If in a party, spread out to minimize damage from Flying Frenzy
 job_specifics:

--- a/_potd_171_enemies/bandersnatch.md
+++ b/_potd_171_enemies/bandersnatch.md
@@ -5,6 +5,9 @@ image: bandersnatch.png
 start_floor: 171
 end_floor: 173
 agro: Sight
+hp: 23464
+attack_damage: 2030
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,7 +17,8 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Catching Claws
-    description: instant cleave attack
+    potency: 130
+    description: 'instant'
 notes:
   - Hits pretty hard
   - 'Doesn''t stop to use any abilities, so the damage is constant'

--- a/_potd_171_enemies/bear.md
+++ b/_potd_171_enemies/bear.md
@@ -5,6 +5,9 @@ image: bear.png
 start_floor: 171
 end_floor: 175
 agro: Sight
+hp: 24460
+attack_damage: 2120
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,7 +17,8 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Savage Swipe
-    description: 'telegraphed conal attack'
+    potency: 300
+    description: 'telegraphed conal AoE'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_171_enemies/bird.md
+++ b/_potd_171_enemies/bird.md
@@ -6,6 +6,9 @@ start_floor: 176
 end_floor: 179
 patrol: true
 agro: Proximity
+hp: 26784
+attack_damage: 2364
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,13 +18,15 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Filoplumes
-    description: tankbuster
+    potency: 130
+    description: 'instant'
   - name: Revelation
-    description: 'telegraphed circle AoE'
+    potency: 300
+    description: 'telegraphed circle AoE; inflicts confused (10s)'
   - name: Tropical Wind
-    description: 'grants an attack boost and haste, and causes it to spam
-    Revelation. Can be interrupted, but not recommended as its casting will
-    give you lots of breathing room'
+    description: 'grants physical damage up (80%, 30s) and haste (30s) to self,
+    and causes it to spam Revelation. Can be interrupted, but not recommended
+    as its casting will give you lots of breathing room'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_171_enemies/coeurl.md
+++ b/_potd_171_enemies/coeurl.md
@@ -1,10 +1,13 @@
 ---
-name: Deep Palace Coeurl
+name: Deep Palace Black Coeurl
 nickname: Coeurl
 image: coeurl.png
 start_floor: 176
 end_floor: 179
 agro: Sight
+hp: 26341
+attack_damage: 2324
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -16,8 +19,8 @@ abilities:
   - name: Megablaster
     description: 'telegraphed conal AoE. Doesn''t use this while you''re
     paralyzed'
-  - name: '?'
-    description: 'applies paralyze'
+  - name: 'Blaster (?)'
+    description: 'inflicts paralyze (30s)'
 notes:
   - 'If there are several, you may want to pull them in quick succession to
     take advantage of diminishing returns on paralyze'

--- a/_potd_171_enemies/dhalmel.md
+++ b/_potd_171_enemies/dhalmel.md
@@ -5,6 +5,9 @@ image: dhalmel.png
 start_floor: 171
 end_floor: 175
 agro: Proximity
+hp: 23906
+attack_damage: 2077
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,9 +17,10 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Whiplash
+    potency: 300
     description: 'telegraphed conal AoE'
   - name: Whistle
-    description: 'grants attack bonus'
+    description: 'grants physical damage up (50%, 15s) to self'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_171_enemies/lion.md
+++ b/_potd_171_enemies/lion.md
@@ -5,6 +5,9 @@ image: lion.png
 start_floor: 174
 end_floor: 178
 agro: Sight
+hp: 25345
+attack_damage: 2221
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,9 +17,11 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Mark of the Beast
-    description: 'instant cleave attack'
+    potency: 130
+    description: 'instant'
   - name: Cry
-    description: 'telegraphed pointblank AoE'
+    potency: 300?
+    description: 'large telegraphed pointblank AoE'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_171_enemies/mimic.md
+++ b/_potd_171_enemies/mimic.md
@@ -5,7 +5,7 @@ image: ../mimic.png
 start_floor: 171
 end_floor: 179
 agro: Proximity
-hp: 34864?
+hp: 34864
 attack_damage: 3064
 attack_type: Physical
 vulnerabilities:

--- a/_potd_171_enemies/mimic.md
+++ b/_potd_171_enemies/mimic.md
@@ -5,6 +5,9 @@ image: ../mimic.png
 start_floor: 171
 end_floor: 179
 agro: Proximity
+hp: 34864?
+attack_damage: 3064
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_171_enemies/sasquatch.md
+++ b/_potd_171_enemies/sasquatch.md
@@ -5,6 +5,9 @@ image: sasquatch.png
 start_floor: 175
 end_floor: 179
 agro: Proximity
+hp: 25899
+attack_damage: 2264
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -13,15 +16,16 @@ vulnerabilities:
   stun: true
   resolution: false
 abilities:
-  - name: Ripe Banana
-    description: 'used out of combat only. Grants a strong attack boost. After
-    using this, it will use Chest Thump every few seconds until the buff
-    expires'
-  - name: Chest Thump
-    description: 'huge 1.5 room instant AoE that applies stacking vulnerability
-    up. Only used out of combat during Ripe Banana'
   - name: Browbeat
-    description: 'tankbuster'
+    potency: 200
+    description: 'instant'
+  - name: Ripe Banana
+    description: 'grants physical damage up (100%, 15s) to self and heals 20%
+    of max HP; only used out of combat'
+  - name: Chest Thump
+    description: 'huge 1.5 room instant AoE that inflicts stacking physical
+    vulnerability up (10% per stack, max 5 stacks, 8s). Only used out of combat
+    during Ripe Banana'
 notes:
   - Hits VERY hard
   - DO NOT pull while it has the attack bonus

--- a/_potd_171_enemies/snowclops.md
+++ b/_potd_171_enemies/snowclops.md
@@ -7,6 +7,9 @@ start_floor: 171
 end_floor: 173
 patrol: true
 agro: Sight
+hp: 23906
+attack_damage: 2077
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -16,9 +19,11 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Glower
+    potency: 300
     description: 'untelegraphed wide line AoE - DO NOT stand in front'
   - name: 100-tonze Swing
-    description: 'untelegraphed pointblank AoE - get away'
+    potency: 600?
+    description: 'untelegraphed pointblank AoE inflicting knockback - get away'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_171_enemies/wisent.md
+++ b/_potd_171_enemies/wisent.md
@@ -6,6 +6,9 @@ start_floor: 174
 end_floor: 176
 patrol: true
 agro: Sight
+hp: 25345
+attack_damage: 2221
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,9 +18,9 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Khoomii
-    description: 'draws players in and applies an extreme heavy debuff; used 30
-    seconds after pull; can use knockback immunity. Draw-in will not work under
-    the Knockback Penalty enchantment'
+    description: 'draws players in and inflicts an extreme heavy debuff (10s);
+    used 30 seconds after pull; can use knockback immunity. Draw-in will not
+    work under the Knockback Penalty enchantment'
   - name: Horroisonous Blast
     description: 'telegraphed pointblank AoE that causes damage and paralyze;
     used immediately after Khoomii, making it difficult to escape'

--- a/_potd_171_enemies/wolf.md
+++ b/_potd_171_enemies/wolf.md
@@ -5,6 +5,9 @@ image: wolf.png
 start_floor: 173
 end_floor: 176
 agro: Sight
+hp: 24903
+attack_damage: 2169
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,8 +17,9 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Sanguine Bite
-    description: 'instant attack that drains HP and applies a strong frostbite
-    (DoT)'
+    potency: 130
+    description: 'instant; absorbs 100% of damage dealt; inflicts frostbite
+    (DoT potency 50, 12s)'
 notes:
   - Hits pretty hard
   - 'Doesn''t stop to use any abilities, so the damage is constant'

--- a/_potd_181_enemies/archaeosaur.md
+++ b/_potd_181_enemies/archaeosaur.md
@@ -5,6 +5,9 @@ image: archaeosaur.png
 start_floor: 184
 end_floor: 188
 agro: Sight
+hp: 27448
+attack_damage: 2603
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -14,6 +17,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Underbite
+    potency: 130
     description: 'tankbuster'
   - name: Primordial Bark
     description: 'telegraphed pointblank AoE'

--- a/_potd_181_enemies/archaeosaur.md
+++ b/_potd_181_enemies/archaeosaur.md
@@ -18,7 +18,7 @@ vulnerabilities:
 abilities:
   - name: Underbite
     potency: 130
-    description: 'tankbuster'
+    description: 'instant'
   - name: Primordial Bark
     description: 'telegraphed pointblank AoE'
 job_specifics:

--- a/_potd_181_enemies/claw.md
+++ b/_potd_181_enemies/claw.md
@@ -7,7 +7,7 @@ start_floor: 185
 end_floor: 189
 agro: Sight
 hp: 28002
-attack_damage: 2687?
+attack_damage: 2687
 attack_type: Physical
 vulnerabilities:
   bind: true

--- a/_potd_181_enemies/claw.md
+++ b/_potd_181_enemies/claw.md
@@ -6,6 +6,9 @@ image: claw.png
 start_floor: 185
 end_floor: 189
 agro: Sight
+hp: 28002
+attack_damage: 2687?
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,8 +17,12 @@ vulnerabilities:
   stun: true
   resolution: false
 abilities:
+  - name: 'Inspire (?)'
+    description: 'instant; draws the target in and inflicts prey. Knockback
+    immunity does not work against the draw-in'
   - name: Impale
-    description: tank buster used on target with Prey status
+    potency: 130
+    description: 'used against players with prey; clears prey status'
   - name: Tail Screw
     description: 'attack that applies slow. Can be outrun'
 notes:

--- a/_potd_181_enemies/crawler.md
+++ b/_potd_181_enemies/crawler.md
@@ -5,6 +5,8 @@ image: crawler.png
 start_floor: 183
 end_floor: 186
 agro: Sound
+hp: 27005
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true

--- a/_potd_181_enemies/dragon.md
+++ b/_potd_181_enemies/dragon.md
@@ -5,6 +5,9 @@ image: dragon.png
 start_floor: 186
 end_floor: 189
 agro: Sight
+hp: 28887
+attack_damage: 2790
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,7 +17,8 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: 'Sheet of Ice'
-    description: 'instant circle AoE that applies a VERY strong DoT'
+    potency: 120
+    description: 'instant circle AoE; inflicts frostbite (DoT potency 100, 21s)'
   - name: 'Granite Rain'
     description: telegraphed pointblank AoE
 job_specifics:

--- a/_potd_181_enemies/garm.md
+++ b/_potd_181_enemies/garm.md
@@ -7,6 +7,9 @@ start_floor: 181
 end_floor: 189
 patrol: true
 agro: Proximity
+hp: 40066
+attack_damage: 3297
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -16,12 +19,19 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: 'The Dragon''s Voice'
-    description: 'untelegraphed donut AoE - get IN. Can be interrupted'
+    potency: 600?
+    description: 'untelegraphed donut AoE - get IN. Inflicts frostbite and
+    deep freeze. Can be interrupted'
   - name: 'The Ram''s Voice'
-    description: 'untelegraphed pointblank AoE - get OUT. Can be interrupted'
+    potency: 600?
+    description: 'untelegraphed pointblank AoE - get OUT. Inflicts
+    electrocution (DoT potency 50, 30s) and paralysis (30s). Can be
+    interrupted'
   - name: 'The Lion''s Breath'
+    potency: 300?
     description: 'telegraphed conal AoE'
   - name: 'The Ram''s Breath'
+    potency: 300?
     description: 'telegraphed conal AoE'
 notes:
   - 'These mostly just spam abilities, doing very little autoattack damage'

--- a/_potd_181_enemies/grenade.md
+++ b/_potd_181_enemies/grenade.md
@@ -6,6 +6,9 @@ image: grenade.png
 start_floor: 181
 end_floor: 184
 agro: Sight
+hp: 25567
+attack_damage: 2414
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true

--- a/_potd_181_enemies/jaundiced_tribunus.md
+++ b/_potd_181_enemies/jaundiced_tribunus.md
@@ -5,8 +5,8 @@ image: jaundiced_tribunus.png
 start_floor: 181
 end_floor: 189
 agro: Proximity
-hp: 41726?
-attack_damage: 4202?
+hp: 41726
+attack_damage: 4202
 attack_type: Physical
 vulnerabilities:
   bind: false

--- a/_potd_181_enemies/jaundiced_tribunus.md
+++ b/_potd_181_enemies/jaundiced_tribunus.md
@@ -5,6 +5,9 @@ image: jaundiced_tribunus.png
 start_floor: 181
 end_floor: 189
 agro: Proximity
+hp: 41726?
+attack_damage: 4202?
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false

--- a/_potd_181_enemies/mimic.md
+++ b/_potd_181_enemies/mimic.md
@@ -5,6 +5,9 @@ image: ../mimic.png
 start_floor: 181
 end_floor: 189
 agro: Proximity
+hp: 37631
+attack_damage: 3585
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_181_enemies/sprite.md
+++ b/_potd_181_enemies/sprite.md
@@ -5,6 +5,10 @@ image: sprite.png
 start_floor: 181
 end_floor: 185
 agro: Sight
+hp: 26563
+attack_damage: 2490
+attack_type: Magic
+attack_name: Blizzard
 vulnerabilities:
   bind: true
   heavy: true
@@ -12,9 +16,6 @@ vulnerabilities:
   slow: false
   stun: true
   resolution: false
-abilities:
-  - name: Blizzard
-    description: 'Used instead of auto-attacks'
 notes:
   - 'Caster - kiting doesn''t help to mitigate damage'
   - 'Can be slowed if transfigured via Pomander of Witching'

--- a/_potd_181_enemies/vindthurs.md
+++ b/_potd_181_enemies/vindthurs.md
@@ -7,6 +7,9 @@ start_floor: 184
 end_floor: 186
 patrol: true
 agro: Proximity
+hp: 27448
+attack_damage: 2603
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true

--- a/_potd_181_enemies/wamoura.md
+++ b/_potd_181_enemies/wamoura.md
@@ -6,6 +6,9 @@ start_floor: 181
 end_floor: 183
 patrol: true
 agro: Sight
+hp: 26009
+attack_damage: 2458
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true

--- a/_potd_181_enemies/wamouracampa.md
+++ b/_potd_181_enemies/wamouracampa.md
@@ -5,6 +5,9 @@ image: wamouracampa.png
 start_floor: 181
 end_floor: 185
 agro: Sound
+hp: 26009
+attack_damage: 2458
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,7 +17,8 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Cannonball
-    description: 'ranged tankbuster'
+    potency: 130
+    description: 'instant ranged attack'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_181_enemies/worm.md
+++ b/_potd_181_enemies/worm.md
@@ -5,6 +5,9 @@ image: worm.png
 start_floor: 181
 end_floor: 189
 agro: Sound
+hp: 35749
+attack_damage: 2900
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,14 +17,22 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Sand Pillar
-    description: 'instant circle AoE used out of combat. Be very careful if
-    there are several worms nearby as getting hit by a few of these at once
-    could kill you'
-notes:
-  - 'Enrages after 30 seconds - does draw-in and a pointblank AoE. Knockback
+    potency: 120
+    description: 'instant circle AoE. Also used out of combat, with potency 75;
+    be very careful if there are several worms nearby, as getting hit by a few
+    of these at once could kill you'
+  - name: Bottomless Desert
+    potency: 20
+    description: 'quick huge pointblank AoE; draws players in. Knockback
     immunity does not work, but draw-in will not work on floors with knockback
-    penalty, making them easier to deal with. The draw-in can also be
-    out-ranged, but it''s big'
+    penalty'
+  - name: Temblor
+    potency: 600
+    description: 'instant pointblank AoE; used immediately after Bottomless
+    Desert'
+notes:
+  - 'Enrages after 30 seconds, using Bottomless Desert followed by Temblor.
+    Knockback penalty blocks the draw-in, making them easier to deal with'
   - 'Can appear on any floor from 181-189, but seems fairly rare in the earlier
     floors, and more common in the later floors'
 job_specifics:

--- a/_potd_191_enemies/bicephalus.md
+++ b/_potd_191_enemies/bicephalus.md
@@ -6,6 +6,9 @@ image: bicephalus.png
 start_floor: 194
 end_floor: 198
 agro: Proximity
+hp: 30215
+attack_damage: 3048
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -15,6 +18,7 @@ vulnerabilities:
   resolution: true
 abilities:
   - name: Glass Punch
+    potency: 150
     description: tank buster
   - name: Catapult
     description: telegraphed circle AoE

--- a/_potd_191_enemies/bicephalus.md
+++ b/_potd_191_enemies/bicephalus.md
@@ -19,9 +19,9 @@ vulnerabilities:
 abilities:
   - name: Glass Punch
     potency: 150
-    description: tank buster
+    description: 'instant'
   - name: Catapult
-    description: telegraphed circle AoE
+    description: 'telegraphed circle AoE'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_191_enemies/dragon.md
+++ b/_potd_191_enemies/dragon.md
@@ -5,7 +5,7 @@ image: dragon.png
 start_floor: 193
 end_floor: 196
 agro: Proximity
-hp: 29772?
+hp: 29772
 attack_damage: 2996
 attack_type: Physical
 vulnerabilities:

--- a/_potd_191_enemies/dragon.md
+++ b/_potd_191_enemies/dragon.md
@@ -5,6 +5,9 @@ image: dragon.png
 start_floor: 193
 end_floor: 196
 agro: Proximity
+hp: 29772?
+attack_damage: 2996
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -16,7 +19,8 @@ abilities:
   - name: Evil Eye
     description: conal gaze AoE - look away, get behind, or get away
   - name: Miasma Breath
-    description: telegraphed conal AoE
+    potency: 300
+    description: telegraphed conal AoE; causes disease
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_191_enemies/fachan.md
+++ b/_potd_191_enemies/fachan.md
@@ -7,6 +7,10 @@ start_floor: 194
 end_floor: 197
 patrol: true
 agro: Sight
+hp: 31211
+attack_damage: 2859
+attack_type: Magic
+attack_name: Stone
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +19,6 @@ vulnerabilities:
   stun: true
   resolution: false
 abilities:
-  - name: Stone
-    description: Used instead of auto-attacks
   - name: Level 5 Death
     description: 'untelegraphed conal gaze AoE causing instant death - look
     away, get behind, or get away'

--- a/_potd_191_enemies/gourmand.md
+++ b/_potd_191_enemies/gourmand.md
@@ -5,6 +5,9 @@ image: gourmand.png
 start_floor: 196
 end_floor: 199
 agro: Proximity
+hp: 32097
+attack_damage: 3140
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -13,10 +16,13 @@ vulnerabilities:
   stun: true
   resolution: true
 abilities:
-  - name: 'Beatdown'
-    description: tank buster
+  - name: Beatdown
+    potency: 130
+    description: 'instant'
   - name: 'Dirty Sneeze'
-    description: 'random target damage and stun; not used vs. solo adventurers'
+    potency: 130?
+    description: 'instant; only used against lower-emnity party members (not
+    used against solo adventurers)'
 job_specifics:
   GNB:
     difficulty: Medium

--- a/_potd_191_enemies/gourmand.md
+++ b/_potd_191_enemies/gourmand.md
@@ -21,7 +21,7 @@ abilities:
     description: 'instant'
   - name: 'Dirty Sneeze'
     potency: 130?
-    description: 'instant; only used against lower-emnity party members (not
+    description: 'instant; only used against lower-enmity party members (not
     used against solo adventurers)'
 job_specifics:
   GNB:

--- a/_potd_191_enemies/hippogryph.md
+++ b/_potd_191_enemies/hippogryph.md
@@ -5,6 +5,9 @@ image: hippogryph.png
 start_floor: 191
 end_floor: 195
 agro: Sight
+hp: 28776?
+attack_damage: 2898
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,9 +17,11 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Beak Snap
-    description: tank buster
+    potency: 130
+    description: 'instant'
   - name: Shriek
-    description: telegraphed pointblank AoE
+    potency: 200
+    description: 'telegraphed pointblank AoE; probably inflicts stun (6s)'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_191_enemies/hippogryph.md
+++ b/_potd_191_enemies/hippogryph.md
@@ -5,7 +5,7 @@ image: hippogryph.png
 start_floor: 191
 end_floor: 195
 agro: Sight
-hp: 28776?
+hp: 28776
 attack_damage: 2898
 attack_type: Physical
 vulnerabilities:

--- a/_potd_191_enemies/iron_corse.md
+++ b/_potd_191_enemies/iron_corse.md
@@ -6,7 +6,7 @@ start_floor: 191
 end_floor: 193
 patrol: true
 agro: Proximity
-hp: 29330?
+hp: 29330
 attack_damage: 2949
 attack_type: Physical
 vulnerabilities:

--- a/_potd_191_enemies/iron_corse.md
+++ b/_potd_191_enemies/iron_corse.md
@@ -6,6 +6,9 @@ start_floor: 191
 end_floor: 193
 patrol: true
 agro: Proximity
+hp: 29330?
+attack_damage: 2949
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
   resolution: true
 abilities:
   - name: Butterfly Float
-    description: '(painful) gap closer. Does this on first agro and every 30
-    seconds. Will destroy non-tanks if it crits'
+    potency: 150
+    description: 'instant gap closer; used on aggro and every 30 seconds
+    afterward. Will destroy non-tanks if it crits'
 job_specifics:
   GNB:
     difficulty: Medium

--- a/_potd_191_enemies/keeper.md
+++ b/_potd_191_enemies/keeper.md
@@ -6,6 +6,9 @@ start_floor: 197
 end_floor: 199
 patrol: true
 agro: Sound
+hp: 32097
+attack_damage: 3140?
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -15,10 +18,12 @@ vulnerabilities:
   resolution: true
 abilities:
   - name: Nail in the Coffin
-    description: tank buster
-  - name: Vengeful Soul
-    description: 'instant circle AoE on random target; not used vs. solo
-    adventurers'
+    potency: 150
+    description: 'instant'
+  - name: Vengeance Soul
+    potency: 130?
+    description: 'instant circle AoE; only used against lower-emnity party
+    members (not used against solo adventurers)'
 notes:
   - 'Highest DPS enemy in PotD'
   - 'If in a party, spread out to minimize damage from Vengeful Soul'

--- a/_potd_191_enemies/keeper.md
+++ b/_potd_191_enemies/keeper.md
@@ -7,7 +7,7 @@ end_floor: 199
 patrol: true
 agro: Sound
 hp: 32097
-attack_damage: 3140?
+attack_damage: 3140
 attack_type: Physical
 vulnerabilities:
   bind: true

--- a/_potd_191_enemies/keeper.md
+++ b/_potd_191_enemies/keeper.md
@@ -22,7 +22,7 @@ abilities:
     description: 'instant'
   - name: Vengeance Soul
     potency: 130?
-    description: 'instant circle AoE; only used against lower-emnity party
+    description: 'instant circle AoE; only used against lower-enmity party
     members (not used against solo adventurers)'
 notes:
   - 'Highest DPS enemy in PotD'

--- a/_potd_191_enemies/knight.md
+++ b/_potd_191_enemies/knight.md
@@ -5,6 +5,9 @@ image: knight.png
 start_floor: 195
 end_floor: 199
 agro: Proximity
+hp: 31211
+attack_damage: 3144
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,14 +16,15 @@ vulnerabilities:
   stun: false
   resolution: true
 abilities:
+  - name: Skullsplinter
+    potency: 130
+    description: 'instant'
   - name: Death Spiral
     description: scary-looking telegraphed donut AoE
-  - name: Skullsplinter
-    description: tank buster
-  - name: '?'
-    description: grants 7s attack bonus
   - name: Ossify
-    description: does damage and grants 15s defense bonus
+    description: 'grants physical damage up (100%, 8s) to self'
+  - name: '?'
+    description: 'grants physical vulnerability down (20s) to self'
 notes:
   - 'Do not fight one of these with a Wraith nearby, as the Wraith can cast
     Accursed Pox outside of combat and fill in the safe spot normally left

--- a/_potd_191_enemies/mimic.md
+++ b/_potd_191_enemies/mimic.md
@@ -5,6 +5,9 @@ image: ../mimic.png
 start_floor: 191
 end_floor: 199
 agro: Proximity
+hp: 41726
+attack_damage: 4202
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_191_enemies/mummy.md
+++ b/_potd_191_enemies/mummy.md
@@ -5,7 +5,7 @@ image: mummy.png
 start_floor: 191
 end_floor: 193
 agro: Proximity
-hp: 28776?
+hp: 28776
 attack_damage: 2898
 attack_type: Physical
 vulnerabilities:

--- a/_potd_191_enemies/mummy.md
+++ b/_potd_191_enemies/mummy.md
@@ -5,6 +5,9 @@ image: mummy.png
 start_floor: 191
 end_floor: 193
 agro: Proximity
+hp: 28776?
+attack_damage: 2898
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,7 +17,8 @@ vulnerabilities:
   resolution: true
 abilities:
   - name: Rotting Bandages
-    description: 'telegraphed conal attack'
+    potency: 130?
+    description: 'telegraphed conal AoE; probably inflicts stun (6s)'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_191_enemies/trap.md
+++ b/_potd_191_enemies/trap.md
@@ -6,7 +6,7 @@ image: trap.png
 start_floor: 191
 end_floor: 194
 agro: Sound
-hp: 28776?
+hp: 28776
 attack_damage: 2716
 attack_type: Physical
 vulnerabilities:

--- a/_potd_191_enemies/trap.md
+++ b/_potd_191_enemies/trap.md
@@ -6,6 +6,9 @@ image: trap.png
 start_floor: 191
 end_floor: 194
 agro: Sound
+hp: 28776?
+attack_damage: 2716
+attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
@@ -14,8 +17,9 @@ vulnerabilities:
   stun: true
   resolution: false
 abilities:
-  - name: 'Swift Sough'
-    description: telegraphed conal AoE
+  - name: Sleetvolley
+    potency: 100
+    description: 'instant ranged attack'
 notes:
   - 'Will not come into melee range if you stay away from it, doing very little
     damage'

--- a/_potd_191_enemies/wraith.md
+++ b/_potd_191_enemies/wraith.md
@@ -5,6 +5,9 @@ image: wraith.png
 start_floor: 191
 end_floor: 199
 agro: Proximity
+hp: 32097
+attack_damage: 3206?
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,11 +17,13 @@ vulnerabilities:
   resolution: true
 abilities:
   - name: Scream
-    description: 'huge telegraphed pointblank AoE that inflicts terror. Can be
-    interrupted'
+    potency: 200?
+    description: 'huge telegraphed pointblank AoE; inflicts terror (10s); can
+    be interrupted'
   - name: Accursed Pox
-    description: 'telegraphed circle AoE. Can be interrupted. Will also cast
-    this outside of combat'
+    potency: 400?
+    description: 'telegraphed circle AoE; inflicts disease; can be interrupted.
+    Also used outside of combat'
 notes:
   - 'Do not fight a Knight with one of these nearby, as Accursed Pox can fill
     in the safe spot of the Knight''s donut AoE'

--- a/_potd_191_enemies/wraith.md
+++ b/_potd_191_enemies/wraith.md
@@ -6,7 +6,7 @@ start_floor: 191
 end_floor: 199
 agro: Proximity
 hp: 32097
-attack_damage: 3206?
+attack_damage: 3206
 attack_type: Physical
 vulnerabilities:
   bind: false

--- a/_potd_floorsets/001.md
+++ b/_potd_floorsets/001.md
@@ -16,7 +16,7 @@ boss_attack_damage: 56
 boss_abilities:
   - name: Whipcrack
     potency: 180
-    description: `tankbuster`
+    description: 'instant'
   - name: Stormwind
     potency: 350
     description: 'telegraphed conal AoE'

--- a/_potd_floorsets/001.md
+++ b/_potd_floorsets/001.md
@@ -11,14 +11,32 @@ respawns: '40s'
 hoard_type: Bronze-trimmed Sack
 boss: Palace Deathgaze
 boss_image: deathgaze.png
+boss_hp: 6170
+boss_attack_damage: 56
+boss_abilities:
+  - name: Whipcrack
+    potency: 180
+    description: `tankbuster`
+  - name: Stormwind
+    potency: 350
+    description: 'telegraphed conal AoE'
+  - name: Bombination
+    potency: 300
+    description: 'telegraphed pointblank AoE; inflicts slow (12s)'
+  - name: Lumisphere
+    potency: 300
+    description: 'telegraphed circle AoE'
+  - name: Aero Blast
+    potency: 80
+    description: 'roomwide AoE; applies windburn (DoT potency 50, 15s)'
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Whipcrack: tankbuster'
-      - 'Stormwind: telegraphed conal AoE'
-      - 'Bombination: telegraphed pointblank AoE; applies 12s slow'
-      - 'Lumisphere: telegraphed circle AoE'
-      - 'Aero Blast: roomwide AoE; applies windburn (DoT, 15s)'
+      - 'Whipcrack'
+      - 'Stormwind'
+      - 'Bombination'
+      - 'Lumisphere'
+      - 'Aero Blast'
 boss_job_specifics:
   GNB:
     timing:

--- a/_potd_floorsets/011.md
+++ b/_potd_floorsets/011.md
@@ -11,17 +11,35 @@ respawns: '1m'
 hoard_type: Bronze-trimmed Sack
 boss: Spurge
 boss_image: spurge.png
+boss_hp: 16165
+boss_attack_damage: 180
+boss_abilities:
+  - name: Bloody Caress
+    potency: 300
+    description: 'instant'
+  - name: Acid Mist
+    description: 'telegraphed pointblank AoE; inflicts poison (DoT potency 75,
+    30s)'
+  - name: Gold Dust
+    description: 'telegraphed circle AoE; inflicts poison (DoT potency 75,
+    30s)'
+  - name: Leafstorm
+    potency: 250
+    description: 'roomwide AoE'
+  - name: Rotten Stench
+    potency: 350
+    description: 'telegraphed wide line AoE'
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Bloody Caress: cleave'
-      - 'Acid Mist: telegraphed pointblank AoE (no damage, 30s poison)'
-      - 'Gold Dust: telegraphed circle AoE (no damage, 30s poison)'
-      - 'Leafstorm: roomwide AoE'
+      - 'Bloody Caress'
+      - 'Acid Mist'
+      - 'Gold Dust'
+      - 'Leafstorm'
       - 'Boss runs to north end and stays there until after Rotten Stench
       phase'
-      - 'Two Palace Hornets adds appear'
-      - 'Rotten Stench x3: telegraphed wide line AoE'
+      - 'Two Palace Hornet adds appear'
+      - 'Rotten Stench x3'
   - 'Kill adds quickly, or they will use Final Sting, which does 70% max HP
   damage (each)'
   - 'Lust can be used to AoE down the adds quickly while continuing to DPS the

--- a/_potd_floorsets/021.md
+++ b/_potd_floorsets/021.md
@@ -11,19 +11,33 @@ respawns: '1m'
 hoard_type: Bronze-trimmed Sack
 boss: Ningishzida
 boss_image: ningishzida.png
+boss_hp: 46768
+boss_attack_damage: 324
+boss_abilities:
+  - name: Dissever
+    potency: 150
+    description: 'instant'
+  - name: Ball of Fire
+    potency: 50
+    description: 'instant circle AoE on random player; leaves burn puddle (DoT
+    potency 350)'
+  - name: Ball of Ice
+    potency: 50
+    description: 'instant circle AoE on random player; leaves heavy puddle'
+  - name: Fear Itself
+    description: 'roomwide donut AoE; inflicts hysteria (10s); must be
+    inside/near boss''s target circle to avoid''
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Dissever: cleave'
-      - 'Ball of Fire: instant circle AoE on random player; leaves burn (DoT)
-      puddle'
-      - 'Ball of Ice: instant circle AoE on random player; leaves heavy puddle'
       - 'Dissever'
       - 'Ball of Fire'
       - 'Ball of Ice'
-      - 'Fear Itself: roomwide donut AoE causing 10s hysteria (no damage). Boss
-      runs to center of room to cast. Must be inside/near boss''s target circle
-      to avoid'
+      - 'Dissever'
+      - 'Ball of Fire'
+      - 'Ball of Ice'
+      - 'Boss runs to center of room'
+      - 'Fear Itself'
   - 'Make sure to stay out of middle for the fire/ice balls to keep a safe spot
   for avoiding Fear Itself'
 boss_job_specifics:

--- a/_potd_floorsets/021.md
+++ b/_potd_floorsets/021.md
@@ -26,7 +26,7 @@ boss_abilities:
     description: 'instant circle AoE on random player; leaves heavy puddle'
   - name: Fear Itself
     description: 'roomwide donut AoE; inflicts hysteria (10s); must be
-    inside/near boss''s target circle to avoid''
+    inside/near boss''s target circle to avoid'
 boss_notes:
   - note: 'Rotation:'
     subnotes:

--- a/_potd_floorsets/031.md
+++ b/_potd_floorsets/031.md
@@ -11,21 +11,39 @@ respawns: '1m'
 hoard_type: Bronze-trimmed Sack
 boss: Ixtab
 boss_image: ixtab.png
+boss_hp: 45616
+boss_attack_damage: 455
+boss_abilities:
+  - name: Ancient Eruption
+    potency: 400
+    description: 'telegraphed circle AoE; leaves a bleed puddle (DoT potency
+    40)'
+  - name: Entropic Flame
+    potency: 400
+    description: 'telegraphed wide line AoE'
+  - name: Accursed Pox
+    potency: 260
+    description: 'telegraphed circle AoE; inflicts disease (30s)'
+  - name: Scream
+    potency: 170
+    description: 'roomwide AoE; inflicts terror (10s) and prey'
+  - name: Shadow Flare
+    potency: 260
+    description: 'roomwide AoE'
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Ancient Eruption (x4): telegraphed circle AoE that leaves a bleed
-        puddle'
+      - 'Ancient Eruption (x4)'
       - 'Adds: 2 Nightmare Bhoots appear'
-      - 'Entropic Flame: telegraphed wide line AoE'
-      - 'Accursed Pox: telegraphed circle AoE; causes disease (30s)'
       - 'Entropic Flame'
       - 'Accursed Pox'
-      - note: 'Scream: roomwide AoE; applies terror (10s) and prey'
+      - 'Entropic Flame'
+      - 'Accursed Pox'
+      - note: 'Scream'
         subnotes:
           - 'If adds are still alive at this point, prey will cause them to
           cast Tornado, likely killing you'
-      - 'Shadow Flare: roomwide AoE damage'
+      - 'Shadow Flare'
 boss_job_specifics:
   GNB:
     timing:

--- a/_potd_floorsets/041.md
+++ b/_potd_floorsets/041.md
@@ -11,18 +11,41 @@ respawns: '2m'
 hoard_type: Bronze-trimmed Sack
 boss: Edda Blackbosom
 boss_image: edda.png
+boss_hp: 101382
+boss_attack_damage: 562
+boss_abilities:
+  - name: Dark Harvest
+    potency: 120
+    description: 'instant'
+  - name: In Health
+    potency: 400
+    description: 'either a huge donut AoE or a large pointblank AoE; pierces
+    Steel and absorbs 100% of damage dealt'
+  - name: In Sickness
+    potency: 80
+    description: 'instant; inflicts disease (20s)'
+  - name: Black Honeymoon
+    potency: 80
+    description: 'roomwide AoE; adds 960 damage (Steel-piercing) for each
+    player who was hit by In Health'
+  - name: Cold Feet
+    description: '360 degree gaze AoE; inflicts confused (10s)'
 boss_notes:
-  - note: 'Abilities:'
+  - note: 'Initial rotation:'
     subnotes:
-      - 'Dark Harvest: cleave'
-      - 'In Health: Sometimes a huge donut AoE, sometimes a large pointblank
-        AoE; pierces Steel and absorbs 100% of damage dealt'
-      - 'In Sickness: causes disease (20s)'
-      - 'Black Honeymoon: roomwide AoE; damage is increased for each person who
-        was hit by In Health'
-      - 'Cold Feet: 360 degree gaze AoE causing confusion (10s)'
-  - 'Non-targetable adds appear outside the arena after a while and do either
-    a circle AoE or multiple line AoEs'
+      - 'Dark Harvest'
+      - 'In Health (pointblank)'
+      - 'Black Honeymoon'
+      - 'Cold Feet'
+      - 'In Health (pointblank)'
+      - 'In Health (donut)'
+      - 'Dark Harvest'
+      - 'In Sickness'
+      - 'Cold Feet'
+      - 'Black Honeymoon'
+  - 'Below 50% health, non-targetable adds may appear outside the arena before
+    a donut In Health cast, doing either a circle AoE (potency 250) or multiple
+    line AoEs (each potency 300)'
   - 'Stay close to avoid In Health easily'
   - 'Make sure to turn for Cold Feet'
 boss_job_specifics:

--- a/_potd_floorsets/051.md
+++ b/_potd_floorsets/051.md
@@ -12,16 +12,31 @@ hoard_type: Iron-trimmed Sack
 resolution_possible: true
 boss: The Black Rider
 boss_image: black_rider.png
+boss_hp: 100276
+boss_attack_damage: 689
+boss_abilities:
+  - name: Geirrothr
+    potency: 80
+    description: 'instant'
+  - name: Hall of Sorrow
+    potency: 60
+    description: 'instant large circle AoE leaving bleed puddle (DoT potency
+    70)'
+  - name: Valfodr
+    potency: 60
+    description: telegraphed charge AoE; inflicts knockback'
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Geirrothr: cleave'
-      - 'Hall of Sorrow: instant large circle AoE leaving bleed puddle'
-      - 'Valfodr: telegraphed charge/knockback AoE; flames appear around the
-        edges of the arena and do telegraphed pointblank AoEs at the same time.
-        Make sure to get knocked into a safe spot or use knockback immunity.
-        The flames explode a couple seconds after the knockback, so there is a
-        bit of time to adjust. Flame explosions deal 70% max HP damage'
+      - 'Geirrothr'
+      - 'Hall of Sorrow'
+      - note: 'Valfodr'
+        subnotes:
+          - 'Flames appear around the edges of the arena and do telegraphed
+            pointblank AoEs at the same time. Make sure to get knocked into a
+            safe spot or use knockback immunity. The flames explode a couple
+            seconds after the knockback, so there is a bit of time to adjust.
+            Flame explosions deal 70% max HP damage'
       - 'Geirrothr'
       - 'Hall of Sorrow'
   - 'Bleed DoT does not stack (standing in overlapping puddles does the same

--- a/_potd_floorsets/061.md
+++ b/_potd_floorsets/061.md
@@ -12,16 +12,29 @@ hoard_type: Iron-trimmed Sack
 resolution_possible: true
 boss: Yaquaru
 boss_image: yaquaru.png
+boss_hp: 102489
+boss_attack_damage: 578
+boss_abilities:
+  - name: Drench
+    potency: 115
+    description: 'instant conal AoE'
+  - name: Electrogenesis
+    potency: 300
+    description: 'telegraphed circle AoE'
+  - name: Douse
+    potency: 400
+    description: 'telegraphed pointblank AoE; leaves behind a puddle which
+    grants haste to the boss. Standing in the puddle does NOT hurt you'
+  - name: 'Fang''s End'
+    potency: 110
+    description: 'inflicts heavy (15s)'
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Drench: untelegraphed instant conal'
-      - 'Electrogenesis: telegraphed circle AoE'
-      - 'Douse: telegraphed pointblank AoE that leaves behind a puddle. Puddle
-        grants haste to the boss. Standing in puddle does NOT hurt you.'
-      - 'Fang''s End: applies heavy (15s)'
       - 'Drench'
       - 'Electrogenesis'
+      - 'Douse'
+      - 'Fang''s End'
   - 'Hit Sprint when it uses Drench if you''re still heavied to escape
     Electrogenesis safely'
   - 'Make sure to drag the boss out of the Douse puddles'

--- a/_potd_floorsets/071.md
+++ b/_potd_floorsets/071.md
@@ -29,7 +29,7 @@ boss_abilities:
     description: 'roomwide AoE; long cast time'
   - name: Maelstrom (tornado)
     potency: 130
-    description: 'telegraphed circle AoE of double the tornado's size that
+    description: 'telegraphed circle AoE of double the tornado''s size that
     draws players in'
   - name: Charybdis (tornado)
     potency: 500

--- a/_potd_floorsets/071.md
+++ b/_potd_floorsets/071.md
@@ -12,21 +12,42 @@ hoard_type: Iron-trimmed Sack
 resolution_possible: true
 boss: Gudanna
 boss_image: gudanna.png
+boss_hp: 136025
+boss_attack_damage: 720
+boss_abilities:
+  - name: Thunderbolt
+    potency: 300
+    description: 'telegraphed conal AoE'
+  - name: Charybdis
+    potency: 300
+    description: 'telegraphed circle AoE that leaves behind a tornado'
+  - name: Trounce
+    potency: 350
+    description: 'large telegraphed conal AoE'
+  - name: Ecliptic Meteor
+    potency: 80% of max HP
+    description: 'roomwide AoE; long cast time'
+  - name: Maelstrom (tornado)
+    potency: 130
+    description: 'telegraphed circle AoE of double the tornado's size that
+    draws players in'
+  - name: Charybdis (tornado)
+    potency: 500
+    description: 'used periodically against players inside the tornado;
+    inflicts windburn (DoT potency 180, 20s)'
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Thunderbolt: telegraphed conal AoE'
-      - 'Charybdis: telegraphed circle AoE that leaves behind a tornado.
-      Tornado periodically expands to double its orignal size, drawing in and
-      damaging anyone it catches'
       - 'Thunderbolt'
-      - 'Trounce: large telegraphed conal AoE; runs to the east end of the arena to cast this'
+      - 'Charybdis'
+      - 'Thunderbolt'
+      - 'Trounce; runs to the east end of the arena to cast this'
       - 'Charybdis'
       - 'Thunderbolt'
       - 'Charybdis'
       - 'Trounce again, but from the west end'
-  - 'Ecliptic Meteor: Casted when boss hits 10% HP; long cast time; deals 80%
-    max HP damage to everyone'
+  - 'At 10% HP, the boss casts Ecliptic Meteor once, then returns to the
+    rotation'
 boss_job_specifics:
   GNB:
     timing:

--- a/_potd_floorsets/081.md
+++ b/_potd_floorsets/081.md
@@ -12,16 +12,39 @@ hoard_type: Iron-trimmed Sack
 resolution_possible: true
 boss: The Godmother
 boss_image: godmother.png
+boss_hp: 165023
+boss_attack_damage: 1003
+boss_abilities:
+  - name: Scalding Scolding
+    potency: 120
+    description: 'instant'
+  - name: Sap
+    potency: 400
+    description: 'telegraphed circle AoE'
+  - name: Self-destruct (Lava Bomb)
+    potency: 400
+    description: 'telegraphed pointblank AoE'
+  - name: Burst (Grey Bomb)
+    potency: 80% of max HP
+    description: 'roomwide AoE'
+  - name: Frost Grenade (Grey Bomb)
+    potency: 400
+    description: 'telegraphed pointblank AoE inflicting stun (2s); also hits
+    enemies, including the boss'
+  - name: Massive Burst
+    potency: 99% of max HP
+    description: 'roomwide AoE'
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Scalding Scolding: strong cleave'
-      - 'Sap: telegraphed circle AoE'
+      - 'Scalding Scolding'
+      - 'Sap'
       - note: 'Grey Bomb spawns along with several untargetable Lava Bombs'
         subnotes:
           - 'Grey Bomb starts using Burst immediately with a long cast time. It
-            must be killed before this goes off to prevent big roomwide damage (80% max HP)'
-          - 'Lava Bombs all use Self-Destruct after a few seconds. This is a
+            must be killed before this goes off to prevent big roomwide damage
+            (80% max HP)'
+          - 'Lava Bombs all use Self-destruct after a few seconds. This is a
             telegraphed pointblank AoE, so don''t get caught in the middle of
             them'
       - 'Sap'
@@ -31,7 +54,7 @@ boss_notes:
       - 'Sap'
       - 'Sap'
       - note: 'Giddy Bomb spawns along with several Lava Bombs as the boss
-        starts casting Massive Burst.'
+        starts casting Massive Burst'
         subnotes:
           - 'Massive Burst will do 99% max HP damage to everyone if it
             finishes'

--- a/_potd_floorsets/091.md
+++ b/_potd_floorsets/091.md
@@ -12,16 +12,35 @@ hoard_type: Iron-trimmed Sack
 resolution_possible: true
 boss: Nybeth Obdilord
 boss_image: nybeth_obdilord.png
+boss_hp: 242942
+boss_attack_damage: 685
+boss_abilities:
+  - name: Abyss
+    potency: 150
+    description: 'instant circle AoE'
+  - name: Shackle
+    potency: 400
+    description: 'telegraphed wide line AoE; inflicts vulnerability up (50%,
+    30s)'
+  - name: Word of Pain
+    potency: 110
+    description: 'instant roomwide(?) AoE'
+  - name: Doom
+    description: 'telegraphed huge conal AoE; inflicts doom (20s). Doom can be
+    removed with Esuna'
+  - name: Summon Darkness
+    description: 'phase change action; summons corse adds'
 boss_notes:
-  - note: 'Summon Darkness: spawns corse adds; used when boss hits certain HP points:'
+  - note: 'Timeline:'
     subnotes:
-    - '90% HP: spawns 2 adds'
-    - '65% HP: spawns 2 adds'
-    - '40% HP: spawns 3 adds'
-  - 'Abyss: instant circle AoE'
-  - 'Shackle: telegraphed wide line AoE; applies vulnerability up (50%, 30s)'
-  - 'Doom: telegraphed huge conal AoE; applies doom (20s); used immediately after
-    summoning the final set of adds'
+    - 'phase 1: uses only Abyss until HP reaches 90%'
+    - 'Summon Darkness: spawns 1 Giant Corse and 1 Bicephalic Corse'
+    - 'phase 2: uses Abyss and Shackle until HP reaches 65%'
+    - 'Summon Darkness: spawns 1 Bicephalic Corse and 1 Iron Corse'
+    - 'phase 3: uses Abyss, Shackle, and Word of Pain until HP reaches 40%'
+    - 'Summon Darkness: spawns 1 Iron, 1 Giant, and 1 Bicephalic Corse'
+    - 'phase 4: rotation of Doom > Abyss > Word of Pain > Shackle > Abyss >
+    Word of Pain'
   - 'Lust can be used to AoE the adds down quickly (3 hits) while also applying
     vulnerability stacks to the boss'
   - 'Adds remain on the battlefield when killed, and will be resurrected after

--- a/_potd_floorsets/101.md
+++ b/_potd_floorsets/101.md
@@ -12,14 +12,32 @@ hoard_type: Silver-trimmed Sack
 resolution_possible: true
 boss: Alicanto
 boss_image: alicanto.png
+boss_hp: 196124
+boss_attack_damage: 1001
+boss_abilities:
+  - name: Whipcrack
+    potency: 120
+    description: `tankbuster`
+  - name: Stormwind
+    potency: 300
+    description: 'telegraphed conal AoE'
+  - name: Bombination
+    potency: 300
+    description: 'telegraphed pointblank AoE; inflicts slow (12s)'
+  - name: Lumisphere
+    potency: 300
+    description: 'telegraphed circle AoE'
+  - name: Aero Blast
+    potency: 80
+    description: 'roomwide AoE; applies windburn (DoT potency 50, 15s)'
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Whipcrack: tankbuster'
-      - 'Stormwind: telegraphed conal AoE'
-      - 'Bombination: telegraphed pointblank AoE; applies 12s slow'
-      - 'Lumisphere: telegraphed circle AoE'
-      - 'Aero Blast: roomwide AoE; applies windburn (DoT, 15s)'
+      - 'Whipcrack'
+      - 'Stormwind'
+      - 'Bombination'
+      - 'Lumisphere'
+      - 'Aero Blast'
 boss_job_specifics:
   GNB:
     timing:

--- a/_potd_floorsets/101.md
+++ b/_potd_floorsets/101.md
@@ -17,7 +17,7 @@ boss_attack_damage: 1001
 boss_abilities:
   - name: Whipcrack
     potency: 120
-    description: `tankbuster`
+    description: 'instant'
   - name: Stormwind
     potency: 300
     description: 'telegraphed conal AoE'

--- a/_potd_floorsets/111.md
+++ b/_potd_floorsets/111.md
@@ -12,17 +12,35 @@ hoard_type: Silver-trimmed Sack
 resolution_possible: true
 boss: Kirtimukha
 boss_image: kirtimukha.png
+boss_hp: 186163
+boss_attack_damage: 1134
+boss_abilities:
+  - name: Bloody Caress
+    potency: 150
+    description: 'instant'
+  - name: Acid Mist
+    description: 'telegraphed pointblank AoE; inflicts poison (DoT potency 150,
+    30s)'
+  - name: Gold Dust
+    description: 'telegraphed circle AoE; inflicts poison (DoT potency 150,
+    30s)'
+  - name: Leafstorm
+    potency: 200
+    description: 'roomwide AoE'
+  - name: Rotten Stench
+    potency: 99999 damage
+    description: 'telegraphed wide line AoE'
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Bloody Caress: cleave'
-      - 'Acid Mist: telegraphed pointblank AoE (no damage, 30s poison)'
-      - 'Gold Dust: telegraphed circle AoE (no damage, 30s poison)'
-      - 'Leafstorm: roomwide AoE'
+      - 'Bloody Caress'
+      - 'Acid Mist'
+      - 'Gold Dust'
+      - 'Leafstorm'
       - 'Boss runs to north end and stays there until after Rotten Stench
       phase'
-      - 'Two Deep Palace Hornets adds appear'
-      - 'Rotten Stench x3: telegraphed wide line AoE (99999 damage)'
+      - 'Two Deep Palace Hornet adds appear'
+      - 'Rotten Stench x3'
   - 'Full rotation takes 56 seconds'
   - 'Kill adds quickly, or they will use Final Sting, which does 70% max HP
   damage (each). This can be outranged, but the adds will keep using it
@@ -76,7 +94,7 @@ boss_job_specifics:
       ready)'
       - 'If using lust, start after the first Rotten Stench of the first
       cycle, then spam for the full duration (avoid poison AoEs) to mostly
-      kill the next pair of adds'
+      kill the next pair of adds. Steel not needed thanks to Kardia'
   WAR:
     timing:
       - '6m30s with 1 lust to AoE first adds and boss, ignoring second set of

--- a/_potd_floorsets/121.md
+++ b/_potd_floorsets/121.md
@@ -12,19 +12,34 @@ hoard_type: Silver-trimmed Sack
 resolution_possible: true
 boss: Alfard
 boss_image: alfard.png
+boss_hp: 46768
+boss_attack_damage: 324
+boss_abilities:
+  - name: Dissever
+    potency: 120
+    description: 'instant'
+  - name: Ball of Fire
+    potency: 75
+    description: 'instant circle AoE on random player; leaves burn puddle (DoT
+    potency 450)'
+  - name: Ball of Ice
+    potency: 75
+    description: 'instant circle AoE on random player; leaves heavy puddle'
+  - name: Fear Itself
+    potency: 500
+    description: 'roomwide donut AoE; inflicts hysteria (10s); must be
+    inside/near boss''s target circle to avoid''
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Dissever: cleave'
-      - 'Ball of Fire: instant circle AoE on random player; leaves burn (DoT)
-      puddle'
-      - 'Ball of Ice: instant circle AoE on random player; leaves heavy puddle'
       - 'Dissever'
       - 'Ball of Fire'
       - 'Ball of Ice'
-      - 'Fear Itself: roomwide donut AoE causing 10s hysteria (with damage).
-      Boss runs to center of room to cast. Must be inside/near boss''s target
-      circle to avoid'
+      - 'Dissever'
+      - 'Ball of Fire'
+      - 'Ball of Ice'
+      - 'Boss runs to center of room'
+      - 'Fear Itself'
   - 'Make sure to stay out of middle for the fire/ice balls to keep a safe spot
   for avoiding Fear Itself'
   - 'Fear Itself is a quicker cast than on floor 30, so get to the center fast'

--- a/_potd_floorsets/121.md
+++ b/_potd_floorsets/121.md
@@ -28,7 +28,7 @@ boss_abilities:
   - name: Fear Itself
     potency: 500
     description: 'roomwide donut AoE; inflicts hysteria (10s); must be
-    inside/near boss''s target circle to avoid''
+    inside/near boss''s target circle to avoid'
 boss_notes:
   - note: 'Rotation:'
     subnotes:

--- a/_potd_floorsets/131.md
+++ b/_potd_floorsets/131.md
@@ -39,7 +39,7 @@ boss_notes:
   - note: 'Rotation:'
     subnotes:
       - 'Ancient Eruption (x4)'
-      - 'Adds: 2 Nightmare Bhoots appear'
+      - 'Adds: 2 Deep Palace Followers appear'
       - 'Entropic Flame'
       - 'Accursed Pox'
       - 'Entropic Flame'

--- a/_potd_floorsets/131.md
+++ b/_potd_floorsets/131.md
@@ -12,6 +12,25 @@ hoard_type: Silver-trimmed Sack
 resolution_possible: true
 boss: Ah Puch
 boss_image: ah_puch.png
+boss_hp: 213391
+boss_attack_damage: 1277
+boss_abilities:
+  - name: Ancient Eruption
+    potency: 400
+    description: 'telegraphed circle AoE; leaves a bleed puddle (DoT potency
+    1300)'
+  - name: Entropic Flame
+    potency: 1100
+    description: 'telegraphed wide line AoE'
+  - name: Accursed Pox
+    potency: 1100?
+    description: 'telegraphed circle AoE'
+  - name: Scream
+    potency: 300
+    description: 'roomwide AoE; inflicts terror (10s) and prey'
+  - name: Shadow Flare
+    potency: 350
+    description: 'roomwide AoE'
 boss_notes:
   - note: 'Vulnerable to resolution'
     subnotes:
@@ -19,18 +38,19 @@ boss_notes:
       resolution'
   - note: 'Rotation:'
     subnotes:
-      - 'Ancient Eruption (x4): telegraphed circle AoE that leaves a bleed
-        puddle'
-      - 'Adds: 2 Deep Palace Followers appear'
-      - 'Entropic Flame: telegraphed wide line AoE'
-      - 'Accursed Pox: telegraphed circle AoE'
+      - 'Ancient Eruption (x4)'
+      - 'Adds: 2 Nightmare Bhoots appear'
       - 'Entropic Flame'
       - 'Accursed Pox'
-      - note: 'Scream: roomwide AoE; applies terror (10s) and prey'
+      - 'Entropic Flame'
+      - 'Accursed Pox'
+      - note: 'Scream'
         subnotes:
           - 'If adds are still alive at this point, prey will cause them to
             cast Tornado, killing you with 99999 damage'
       - 'Shadow Flare: roomwide AoE damage'
+  - 'Bleed pool DoT, Entropic Flame, and (presumably) Accursed Pox will
+    one-shot DPS/healers - stay away'
 boss_job_specifics:
   GNB:
     notes:

--- a/_potd_floorsets/141.md
+++ b/_potd_floorsets/141.md
@@ -12,31 +12,56 @@ hoard_type: Silver-trimmed Sack
 resolution_possible: true
 boss: Tisiphone
 boss_image: tisiphone.png
+boss_hp: 249251
+boss_attack_damage: 1835
+boss_abilities:
+  - name: Dark Mist
+    potency: 320?
+    description: 'telegraphed pointblank AoE; inflicts terror (10s)'
+  - name: Void Fire IV
+    potency: 350
+    description: 'large telegraphed circle AoE'
+  - name: Void Aero
+    potency: 350?
+    description: 'telegraphed wide line AoE'
+  - name: Summon Darkness
+    description: 'summons one of four types of adds (see rotation)'
+  - name: Fatal Allure
+    description: 'draws succubus add to boss and inflicts terror'
+  - name: Blood Sword
+    description: 'kills succubus add, absorbing its remaining HP'
+  - name: Blood Rain
+    potency: 350
+    description: 'roomwide AoE; also hits zombie adds'
+  - name: Sweet Steel (succubus add)
+    potency: 120
+    description: 'instant'
+  - name: Void Fire II (succubus add)
+    potency: 300?
+    description: 'telegraphed circle AoE'
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Void Fire IV: telegraphed circle AoE'
+      - 'Void Fire IV'
       - 'Summon Darkness (Gargoyle): calls an untargetable gargoyle that will
         use a large telegraphed line AoE at the same time as Dark Mist'
-      - 'Dark Mist: telegraphed circle AoE; applies terror (10s)'
+      - 'Dark Mist'
       - 'Summon Darkness (Zombies): calls 4 zombie adds that will slowly crawl
         towards you. If one touches you, you will be bound until it dies'
       - 'Void Fire IV'
-      - 'Void Aero: telegraphed large line AoE'
+      - 'Void Aero'
       - 'Summon Darkness (Vodoriga): calls an untargetable vodoriga that will
         use a telegraphed circle AoE just after the next Void Fire IV'
       - 'Void Fire IV'
       - 'Dark Mist'
       - 'Summon Darkness (Succubus): calls a succubus add - in addition to
-        autoattacks, casts Void Fire II: telegraphed circle AoE'
+        autoattacks, uses Sweet Steel and Void Fire II'
       - 'Void Aero'
       - 'Void Fire IV'
-      - 'Fatal Allure: Calls the succubus to her side'
-      - 'Blood Sword: Kills the succubus, draining its remaining HP. This is
-        1:1, so whether you DPS the add or the boss doesn''t matter in terms of
-        damage'
-      - 'Blood Rain: roomwide big damage. Any zombies still present are
-        destroyed by this too'
+      - 'Fatal Allure'
+      - 'Blood Sword - the HP drain is 1:1, so whether you DPS the add or the
+        boss doesn''t matter in terms of damage'
+      - 'Blood Rain - kills any remaining zombies'
   - 'Entire rotation is about 1m50s'
   - 'Don''t let the zombies catch you'
   - 'Physical ranged jobs can just kite the zombies until they despawn. It''s

--- a/_potd_floorsets/141.md
+++ b/_potd_floorsets/141.md
@@ -27,7 +27,7 @@ boss_abilities:
   - name: Summon Darkness
     description: 'summons one of four types of adds (see rotation)'
   - name: Fatal Allure
-    description: 'draws succubus add to boss and inflicts terror'
+    description: 'draws succubus add to boss and inflicts terror on it'
   - name: Blood Sword
     description: 'kills succubus add, absorbing its remaining HP'
   - name: Blood Rain

--- a/_potd_floorsets/151.md
+++ b/_potd_floorsets/151.md
@@ -12,17 +12,31 @@ hoard_type: Gold-trimmed Sack
 resolution_possible: true
 boss: Todesritter
 boss_image: todesritter.png
+boss_hp: 332040
+boss_attack_damage: 2751
+boss_abilities:
+  - name: Geirrothr
+    potency: 65
+    description: 'instant'
+  - name: Hall of Sorrow
+    potency: 65
+    description: 'instant large circle AoE leaving bleed puddle (DoT potency
+    100)'
+  - name: Valfodr
+    potency: 60
+    description: telegraphed charge AoE; inflicts knockback'
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Geirrothr: cleave'
-      - 'Hall of Sorrow: instant large circle AoE leaving bleed puddle. Stay
-        out of these'
-      - 'Valfodr: telegraphed charge/knockback AoE; flames appear around the
-        edges of the arena and do telegraphed pointblank AoEs at the same time.
-        Make sure to get knocked into a safe spot or use knockback immunity.
-        The flames explode a couple seconds after the knockback, so there is a
-        bit of time to adjust. Flame explosions deal 70% max HP damage'
+      - 'Geirrothr'
+      - 'Hall of Sorrow'
+      - note: 'Valfodr'
+        subnotes:
+          - 'Flames appear around the edges of the arena and do telegraphed
+            pointblank AoEs at the same time. Make sure to get knocked into a
+            safe spot or use knockback immunity. The flames explode a couple
+            seconds after the knockback, so there is a bit of time to adjust.
+            Flame explosions deal 70% max HP damage'
       - 'Geirrothr'
       - 'Hall of Sorrow'
   - 'Bleed DoT does not stack (standing in overlapping puddles does the same

--- a/_potd_floorsets/161.md
+++ b/_potd_floorsets/161.md
@@ -12,15 +12,30 @@ hoard_type: Gold-trimmed Sack
 resolution_possible: true
 boss: Yulunggu
 boss_image: yulunggu.png
+boss_hp: 348642
+boss_attack_damage: 2202
+boss_abilities:
+  - name: Drench
+    potency: 115
+    description: 'instant conal AoE'
+  - name: Electrogenesis
+    potency: 250
+    description: 'telegraphed circle AoE'
+  - name: Douse
+    potency: 400?
+    description: 'telegraphed pointblank AoE; leaves behind a puddle which
+    grants haste and attack bonus to the boss. Standing in the puddle does NOT
+    hurt you'
+  - name: 'Fang''s End'
+    potency: 100
+    description: 'inflicts heavy (15s)'
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Drench: untelegraphed instant conal'
-      - 'Electrogenesis: telegraphed circle AoE'
-      - 'Douse: telegraphed pointblank AoE that leaves behind a puddle. Puddle
-        grants haste and attack bonus to the boss. Standing in puddle does NOT
-        hurt you.'
-      - 'Fang''s End: applies heavy (15s)'
+      - 'Drench'
+      - 'Electrogenesis'
+      - 'Douse'
+      - 'Fang''s End'
   - 'Hit Sprint when it uses Drench if you''re still heavied to escape
     Electrogenesis safely'
   - 'If you''re kiting, it is a good idea to try to pull the boss to the same

--- a/_potd_floorsets/171.md
+++ b/_potd_floorsets/171.md
@@ -29,7 +29,7 @@ boss_abilities:
     description: 'roomwide AoE; medium cast time'
   - name: Maelstrom (tornado)
     potency: 130?
-    description: 'telegraphed circle AoE of double the tornado's size that
+    description: 'telegraphed circle AoE of double the tornado''s size that
     draws players in'
   - name: Charybdis (tornado)
     potency: 500?

--- a/_potd_floorsets/171.md
+++ b/_potd_floorsets/171.md
@@ -12,19 +12,42 @@ hoard_type: Gold-trimmed Sack
 resolution_possible: true
 boss: Dendainsonne
 boss_image: dendainsonne.png
+boss_hp: 373545
+boss_attack_damage: 3268
+boss_abilities:
+  - name: Thunderbolt
+    potency: 300
+    description: 'telegraphed conal AoE'
+  - name: Charybdis
+    potency: 300?
+    description: 'telegraphed circle AoE that leaves behind a tornado'
+  - name: Trounce
+    potency: 350?
+    description: 'large telegraphed conal AoE'
+  - name: Ecliptic Meteor
+    potency: 80% of max HP
+    description: 'roomwide AoE; medium cast time'
+  - name: Maelstrom (tornado)
+    potency: 130?
+    description: 'telegraphed circle AoE of double the tornado's size that
+    draws players in'
+  - name: Charybdis (tornado)
+    potency: 500?
+    description: 'used periodically against players inside the tornado'
 boss_notes:
-  - 'Thunderbolt: telegraphed conal AoE'
-  - 'Charybdis: telegraphed circle AoE that leaves behind a tornado. Tornado
-    periodically expands to double its orignal size, drawing in and damaging
-    anyone it catches'
-  - 'Trounce: large telegraphed conal AoE. Alternates running to the north or
-    south end of the arena to use this'
-  - 'Rotation: Thunderbolt &gt; Charybdis x2 &gt; Thunderbolt &gt; Trounce from
-    south end &gt; Charybdis x2 &gt; Thunderbolt &gt; Charybdis &gt; Trounce
-    from north end &gt; Repeat until 15%'
-  - Enters enrage mode at 15% - stands up and casts Ecliptic Meteor dealing 80%
-    max HP damage to everyone in the party. Continues to cast this over and over
-    until the fight ends
+  - note: 'Rotation:'
+    subnotes:
+      - 'Thunderbolt'
+      - 'Charybdis (x2)'
+      - 'Thunderbolt'
+      - 'Trounce; runs to the south end of the arena to cast this'
+      - 'Charybdis (x2)'
+      - 'Thunderbolt'
+      - 'Charybdis'
+      - 'Trounce again, but from the north end'
+  - Enters enrage mode at 15% - stands up and casts Ecliptic Meteor, dealing
+    80% max HP damage to everyone in the party. Continues to cast this over and
+    over until the fight ends
   - 'If you are standing in front of him during meteors, he can also autoattack
     you (so don''t do that!)'
   - 'Most jobs require a very strict strategy to get through this final push.

--- a/_potd_floorsets/181.md
+++ b/_potd_floorsets/181.md
@@ -12,10 +12,32 @@ hoard_type: Gold-trimmed Sack
 resolution_possible: true
 boss: The Godfather
 boss_image: godfather.png
+boss_hp: 415050
+boss_attack_damage: 4145
+boss_abilities:
+  - name: Scalding Scolding
+    potency: 150
+    description: 'instant'
+  - name: Sap
+    potency: 250
+    description: 'telegraphed circle AoE'
+  - name: Hypothermal Combustion (Giddy Bomb)
+    potency: 180?
+    description: 'telegraphed pointblank AoE; inflicts deep freeze'
+  - name: Hypothermal Combustion (Remedy Bomb)
+    potency: 80% of max HP
+    description: 'roomwide AoE; inflicts deep freeze (DoT potency 15, 5s)'
+  - name: Flashthoom (Grey Bomb)
+    potency: 180?
+    description: 'telegraphed pointblank AoE inflicting stun (2s); also hits
+    enemies, including the boss'
+  - name: Massive Burst
+    potency: 99% of max HP
+    description: 'roomwide AoE'
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Scalding Scolding: strong cleave'
+      - 'Scalding Scolding'
       - note: 'Remedy Bomb (blue) spawns along with several untargetable Giddy
         Bombs'
         subnotes:
@@ -25,7 +47,7 @@ boss_notes:
           - 'Giddy Bombs all use Hypothermal Combustion after a few seconds.
             Theirs is a small telegraphed pointblank AoE with a short cast
             time, so stay away from them'
-      - 'Sap (x3): telegraphed circle AoE'
+      - 'Sap (x3)'
       - 'Scalding Scolding'
       - 'Sap'
       - note: 'Lava Bomb (red) spawns along with several Giddy Bombs as the


### PR DESCRIPTION
Overall notes:
 - I added attack type (physical/magic) for autoattacks since that can be trivially determined by whether the enemy can be slowed without witching.
 - Enemy attack damage is listed with magic and physical damage normalized to the same player defense power. Physical attack data is taken directly from observed damage vs healers; magic attack data is normalized to physical data by comparing with same-level (same-HP) enemies on the same set, which generally also have the same attack power.
 - Consequently, healers and magic DPS will take slightly less magic damage than listed; physical DPS will take slightly less physical damage than listed; tanks will take a lot less damage of both types.
 - Enemy attack damage will obviously vary with player level (early floors) and aetherpool (everywhere) due to different player defense values.
 - HP/damage/potency values marked with a "?" ("hp: 12345?" "potency: 300?" etc.) are estimates because I don't have enough data to confirm accurate values, or (for Deep Palace enemies) because I've copied the potency value from the lower-level Palace enemy's same ability but haven't verified that the potency is unchanged.
 - Some odd-looking potency values (260, etc) may be due to attacks dealing special damage which isn't affected by player defense. We'll have to wait for 6.3 to confirm that.
 - Skill names marked with "(?)" are names I haven't been able to confirm in English; these are typically instant abilities which deal no damage, like the PotD Yarzon's vuln-up skill, and only show up in the battle log. The listed names are translations from Japanese.
 - I've consistently described all instant-type abilities as "instant", per our discussion (in some cases changing previous "tankbuster" or "cleave" terminology for the sake of consistency).