### PR TITLE
Edda's Dark Harvest is not an instant.

### DIFF
--- a/_potd_floorsets/041.md
+++ b/_potd_floorsets/041.md
@@ -16,7 +16,7 @@ boss_attack_damage: 562
 boss_abilities:
   - name: Dark Harvest
     potency: 120
-    description: 'instant'
+    description: 'cleave'
   - name: In Health
     potency: 400
     description: 'either a huge donut AoE or a large pointblank AoE; pierces


### PR DESCRIPTION
My mistake - I misremembered it as an instant when updating the ability list, but it has a cast bar. I'm not sure whether it's single target or AoE, but reverting to the previous wording ("cleave") for now.