### PR TITLE
Add stats/abilities for HoH enemies.

### DIFF
--- a/_data/changelog.yml
+++ b/_data/changelog.yml
@@ -1,3 +1,13 @@
+- date: 2022-12-09
+  updates:
+    - 'Added HoH enemy stats and ability data, courtesy of vaxherd'
+    - 'Split Heavenly Saikoro into two enemies to account for the two varieties
+      (Tornado and Aero)'
+    - 'Corrected Heavenly Kyozo floor range (can spawn on floor 98)'
+    - 'Noted that diminishing returns do not apply to PotD Anzu''s stun'
+    - 'Added potency (300) for Deep Palace Tursus''s Chilling Cyclone'
+    - 'Added attack stats for Deep Palace Crawler'
+    - 'Added missing Dragon's Breath to Deep Palace Garm'
 - date: 2022-12-08
   updates:
     - 'Fixed an issue with enemy details not cycling correctly'

--- a/_data/changelog.yml
+++ b/_data/changelog.yml
@@ -7,7 +7,7 @@
     - 'Noted that diminishing returns do not apply to PotD Anzu''s stun'
     - 'Added potency (300) for Deep Palace Tursus''s Chilling Cyclone'
     - 'Added attack stats for Deep Palace Crawler'
-    - 'Added missing Dragon's Breath to Deep Palace Garm'
+    - 'Added missing Dragon''s Breath to Deep Palace Garm'
 - date: 2022-12-08
   updates:
     - 'Fixed an issue with enemy details not cycling correctly'

--- a/_hoh_001_enemies/amikiri.md
+++ b/_hoh_001_enemies/amikiri.md
@@ -6,6 +6,9 @@ start_floor: 4
 end_floor: 6
 patrol: true
 agro: Sight
+hp: 3127
+attack_damage: 639
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,6 +16,8 @@ vulnerabilities:
   slow: true
   stun: true
 abilities:
-  - name: 'Shuck'
-    description: 'tank buster; very high damage; possible to outrange'
+  - name: Shuck
+    potency: 300
+    description: 'tankbuster; inflicts concussion (DoT potency 50, 30s);
+    possible to outrange'
 ---

--- a/_hoh_001_enemies/ango.md
+++ b/_hoh_001_enemies/ango.md
@@ -6,10 +6,17 @@ image: ango.png
 start_floor: 8
 end_floor: 9
 agro: Sight
+hp: 4218
+attack_damage: 730
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Flounder
+    potency: 300
+    description: 'telegraphed line AoE; inflicts knockback'
 ---

--- a/_hoh_001_enemies/bombfish.md
+++ b/_hoh_001_enemies/bombfish.md
@@ -5,10 +5,17 @@ image: bombfish.png
 start_floor: 1
 end_floor: 4
 agro: Sight
+hp: 2991
+attack_damage: 602
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: 1000 Spines
+    potency: 300
+    description: 'telegraphed pointblank AoE; inflicts paralysis (15s)'
 ---

--- a/_hoh_001_enemies/coralshell.md
+++ b/_hoh_001_enemies/coralshell.md
@@ -17,6 +17,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Bubble Bath
+    potency: n/a
     description: 'instant conal AoE; inflicts sleep (9s)'
   - name: Bubble Shower
     potency: 300

--- a/_hoh_001_enemies/coralshell.md
+++ b/_hoh_001_enemies/coralshell.md
@@ -20,5 +20,6 @@ abilities:
     description: 'instant conal AoE; inflicts sleep (9s)'
   - name: Bubble Shower
     potency: 300
-    description: 'telegraphed conal AoE; used immediately after Bubble Bath (order can change after the first time)'
+    description: 'telegraphed conal AoE; used immediately after Bubble Bath
+    (order can change after the first time)'
 ---

--- a/_hoh_001_enemies/coralshell.md
+++ b/_hoh_001_enemies/coralshell.md
@@ -6,10 +6,19 @@ image: coralshell.png
 start_floor: 4
 end_floor: 5
 agro: Sight
+hp: 3036
+attack_damage: 629
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Bubble Bath
+    description: 'instant conal AoE; inflicts sleep (9s)'
+  - name: Bubble Shower
+    potency: 300
+    description: 'telegraphed conal AoE; used immediately after Bubble Bath (order can change after the first time)'
 ---

--- a/_hoh_001_enemies/gyuki.md
+++ b/_hoh_001_enemies/gyuki.md
@@ -6,10 +6,18 @@ image: gyuki.png
 start_floor: 5
 end_floor: 7
 agro: Sight
+hp: 3336
+attack_damage: 665
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: true
   slow: true
   stun: false
+abilities:
+  - name: Aqua Blast
+    potency: 300
+    description: 'large telegraphed conal AoE; inflicts dropsy (DoT potency 50,
+    15s)'
 ---

--- a/_hoh_001_enemies/kraken.md
+++ b/_hoh_001_enemies/kraken.md
@@ -5,10 +5,17 @@ image: kraken.png
 start_floor: 6
 end_floor: 9
 agro: Proximity
+hp: 3374
+attack_damage: 677
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Water III
+    potency: 350
+    description: 'telegraphed circle AoE'
 ---

--- a/_hoh_001_enemies/matamata.md
+++ b/_hoh_001_enemies/matamata.md
@@ -20,5 +20,5 @@ abilities:
     description: 'inflicts burns (DoT potency 50, 30s)'
   - name: Embalming Earth
     potency: 200
-    description: 'inflicts knockback; can be interrutped'
+    description: 'inflicts knockback; can be interrupted'
 ---

--- a/_hoh_001_enemies/matamata.md
+++ b/_hoh_001_enemies/matamata.md
@@ -5,10 +5,20 @@ image: matamata.png
 start_floor: 8
 end_floor: 9
 agro: Sight
+hp: 4218
+attack_damage: 730
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Scalding Breath
+    potency: 300
+    description: 'inflicts burns (DoT potency 50, 30s)'
+  - name: Embalming Earth
+    potency: 200
+    description: 'inflicts knockback; can be interrutped'
 ---

--- a/_hoh_001_enemies/mimic.md
+++ b/_hoh_001_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Malice
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_hoh_001_enemies/mimic.md
+++ b/_hoh_001_enemies/mimic.md
@@ -6,6 +6,9 @@ image: ../mimic_bronze.png
 start_floor: 7
 end_floor: 9
 agro: Proximity
+hp: 5905
+attack_damage: 556
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Malice
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in bronze chests'

--- a/_hoh_001_enemies/mutsu.md
+++ b/_hoh_001_enemies/mutsu.md
@@ -6,10 +6,16 @@ image: mutsu.png
 start_floor: 1
 end_floor: 3
 agro: Sight
+hp: 2877
+attack_damage: 582
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: 'Sea Spray (?)'
+    description: 'instant; inflicts physical vulnerability up (50%, 9s)'
 ---

--- a/_hoh_001_enemies/mutsu.md
+++ b/_hoh_001_enemies/mutsu.md
@@ -17,5 +17,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Sea Spray (?)'
+    potency: n/a
     description: 'instant; inflicts physical vulnerability up (50%, 9s)'
 ---

--- a/_hoh_001_enemies/naked_yumemi.md
+++ b/_hoh_001_enemies/naked_yumemi.md
@@ -16,5 +16,5 @@ vulnerabilities:
   slow: true
   stun: true
 notes:
-  - 'Autoattack inflicts heavy (4s)'
+  - 'Auto-attack inflicts heavy (4s)'
 ---

--- a/_hoh_001_enemies/naked_yumemi.md
+++ b/_hoh_001_enemies/naked_yumemi.md
@@ -6,10 +6,15 @@ image: naked_yumemi.png
 start_floor: 1
 end_floor: 2
 agro: Sight
+hp: 2877
+attack_damage: 410
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: true
+notes:
+  - 'Autoattack inflicts heavy (4s)'
 ---

--- a/_hoh_001_enemies/onryo.md
+++ b/_hoh_001_enemies/onryo.md
@@ -5,10 +5,17 @@ image: onryo.png
 start_floor: 3
 end_floor: 5
 agro: Proximity
+hp: 3036
+attack_damage: 304
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Tentacle
+    potency: 80
+    description: 'instant; inflicts concussion (DoT potency 50, 15s)'
 ---

--- a/_hoh_001_enemies/shark.md
+++ b/_hoh_001_enemies/shark.md
@@ -6,6 +6,9 @@ start_floor: 1
 end_floor: 3
 patrol: true
 agro: Sight
+hp: 3036
+attack_damage: 697
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -13,6 +16,7 @@ vulnerabilities:
   slow: true
   stun: true
 abilities:
-  - name: 'Jaws'
-    description: 'tank buster; very high damage; possible to outrange'
+  - name: Jaws
+    potency: 300
+    description: 'tankbuster; very high damage; possible to outrange'
 ---

--- a/_hoh_001_enemies/uwabami.md
+++ b/_hoh_001_enemies/uwabami.md
@@ -6,6 +6,9 @@ image: uwabami.png
 start_floor: 6
 end_floor: 7
 agro: Sight
+hp: 3336
+attack_damage: 665
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,6 +16,6 @@ vulnerabilities:
   slow: true
   stun: true
 abilities:
-  - name: 'Stone Gaze'
-    description: '360 degree gaze causing petrify - look away!'
+  - name: Stone Gaze
+    description: '360 degree gaze inflicting petrify (15s) - look away!'
 ---

--- a/_hoh_001_enemies/uwabami.md
+++ b/_hoh_001_enemies/uwabami.md
@@ -17,5 +17,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Stone Gaze
+    potency: n/a
     description: '360 degree gaze inflicting petrify (15s) - look away!'
 ---

--- a/_hoh_001_enemies/yumemi.md
+++ b/_hoh_001_enemies/yumemi.md
@@ -7,10 +7,19 @@ start_floor: 7
 end_floor: 9
 patrol: true
 agro: Sight
+hp: 4218
+attack_damage: 730
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Static Charge
+    description: grants counterattack (potency 100, 6s) to self
+  - name: Blanket Thunder
+    potency: 250
+    description: telegraphed pointblank AoE
 ---

--- a/_hoh_001_enemies/yumemi.md
+++ b/_hoh_001_enemies/yumemi.md
@@ -18,6 +18,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Static Charge
+    potency: n/a
     description: grants counterattack (potency 100, 6s) to self
   - name: Blanket Thunder
     potency: 250

--- a/_hoh_011_enemies/amagoi.md
+++ b/_hoh_011_enemies/amagoi.md
@@ -20,5 +20,6 @@ abilities:
     potency: 500
     description: 'large telegraphed pointblank AoE'
   - name: 'Strengthen Shell (?)'
+    potency: n/a
     description: 'grants physical vulnerability down (90%, 20s) to self'
 ---

--- a/_hoh_011_enemies/amagoi.md
+++ b/_hoh_011_enemies/amagoi.md
@@ -6,10 +6,19 @@ image: amagoi.png
 start_floor: 17
 end_floor: 19
 agro: Sight
+hp: 6269
+attack_damage: 901
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: true
   slow: true
   stun: false
+abilities:
+  - name: Tortoise Stomp
+    potency: 500
+    description: 'large telegraphed pointblank AoE'
+  - name: 'Strengthen Shell (?)'
+    description: 'grants physical vulnerability down (90%, 20s) to self'
 ---

--- a/_hoh_011_enemies/aomino.md
+++ b/_hoh_011_enemies/aomino.md
@@ -7,10 +7,20 @@ start_floor: 17
 end_floor: 19
 patrol: true
 agro: Sight
+hp: 6269
+attack_damage: 803
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Ceras
+    potency: 100
+    description: 'instant; inflicts poison (DoT potency 50, 30s)'
+  - name: 'Hydrocannon'
+    potency: 500
+    description: 'telegraphed line AoE; inflicts knockback'
 ---

--- a/_hoh_011_enemies/apa.md
+++ b/_hoh_011_enemies/apa.md
@@ -5,12 +5,20 @@ image: apa.png
 start_floor: 15
 end_floor: 17
 agro: Proximity
+hp: 5977
+attack_damage: 849
+attack_type: Magic
+attack_name: Water
 vulnerabilities:
   bind: false
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Water III
+    potency: 250
+    description: 'telegraphed circle AoE (follows targeted player position)'
 notes:
   - 'Can only be slowed with Arm''s Length if transfigured via Pomander of
   Witching since it doesn''t normally do melee auto-attacks'

--- a/_hoh_011_enemies/hakagiri.md
+++ b/_hoh_011_enemies/hakagiri.md
@@ -6,10 +6,17 @@ image: hakagiri.png
 start_floor: 13
 end_floor: 15
 agro: Sight
+hp: 5605
+attack_damage: 827
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Scale Ripple
+    potency: 350
+    description: 'telegraphed pointblank AoE; inflicts knockback'
 ---

--- a/_hoh_011_enemies/hand.md
+++ b/_hoh_011_enemies/hand.md
@@ -6,6 +6,9 @@ start_floor: 14
 end_floor: 16
 patrol: true
 agro: Sight
+hp: 5756
+attack_damage: 748
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,7 +16,11 @@ vulnerabilities:
   slow: true
   stun: true
 abilities:
-  - name: 'Wash Away'
-    description: 'Enrage BIG damage and knockback used after 30s; can be
-    interrupted'
+  - name: Fluid Strike
+    potency: 130
+    description: 'instant'
+  - name: Wash Away
+    potency: 1000
+    description: 'conal(?) AoE enrage used after 30s; inflicts knockback; can
+    be interrupted'
 ---

--- a/_hoh_011_enemies/korpokkur.md
+++ b/_hoh_011_enemies/korpokkur.md
@@ -15,7 +15,7 @@ vulnerabilities:
   slow: true
   stun: true
 abilities:
-  - name: Buller's Drop
+  - name: 'Buller''s Drop'
     potency: 120
     description: 'instant'
   - name: Spiritus

--- a/_hoh_011_enemies/korpokkur.md
+++ b/_hoh_011_enemies/korpokkur.md
@@ -5,10 +5,20 @@ image: korpokkur.png
 start_floor: 11
 end_floor: 13
 agro: Sight
+hp: 5272
+attack_damage: 624
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Buller's Drop
+    potency: 120
+    description: 'instant'
+  - name: Spiritus
+    potency: 300
+    description: 'telegraphed conal AoE; inflicts dropsy (potency 50, 30s)'
 ---

--- a/_hoh_011_enemies/mimic.md
+++ b/_hoh_011_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Malice
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_hoh_011_enemies/mimic.md
+++ b/_hoh_011_enemies/mimic.md
@@ -6,6 +6,9 @@ image: ../mimic_bronze.png
 start_floor: 11
 end_floor: 19
 agro: Proximity
+hp: 8732
+attack_damage: 1170
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Malice
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in bronze chests'

--- a/_hoh_011_enemies/namazu.md
+++ b/_hoh_011_enemies/namazu.md
@@ -6,10 +6,20 @@ start_floor: 11
 end_floor: 14
 patrol: true
 agro: Sight
+hp: 5390
+attack_damage: 676
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Triple Trident
+    potency: 45 (x3)
+    description: 'instant 3-hit attack'
+  - name: Tingle
+    potency: 360
+    description: 'telegraphed pointblank AoE; inflicts paralysis (30s)'
 ---

--- a/_hoh_011_enemies/otokage.md
+++ b/_hoh_011_enemies/otokage.md
@@ -17,9 +17,11 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Nightmarish Light
+    potency: n/a
     description: '360 degree gaze inflicting seduced (6s), which will cause you
     to walk into Garish Light'
   - name: Garish Light
+    potency: n/a
     description: 'telegraphed pointblank AoE inflicting minimum (6s); used
     immediately after Nightmarish Light'
 ---

--- a/_hoh_011_enemies/otokage.md
+++ b/_hoh_011_enemies/otokage.md
@@ -6,6 +6,9 @@ image: otokage.png
 start_floor: 15
 end_floor: 17
 agro: Sight
+hp: 5977
+attack_damage: 849
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,10 +16,10 @@ vulnerabilities:
   slow: true
   stun: true
 abilities:
-  - name: 'Nightmarish Light'
-    description: '360 degree gaze causing seduction, which will cause you to
-    walk into Garish Light'
-  - name: 'Garish Light'
-    description: 'telegraphed pointblank AoE causing minimum; used immediately
-    after Nightmarish Light'
+  - name: Nightmarish Light
+    description: '360 degree gaze inflicting seduced (6s), which will cause you
+    to walk into Garish Light'
+  - name: Garish Light
+    description: 'telegraphed pointblank AoE inflicting minimum (6s); used
+    immediately after Nightmarish Light'
 ---

--- a/_hoh_011_enemies/shiomushi.md
+++ b/_hoh_011_enemies/shiomushi.md
@@ -6,10 +6,17 @@ image: shiomushi.png
 start_floor: 11
 end_floor: 14
 agro: Sight
+hp: 5347
+attack_damage: 788
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Shatter
+    potency: 300
+    description: 'telegraphed pointblank AoE'
 ---

--- a/_hoh_011_enemies/shioname.md
+++ b/_hoh_011_enemies/shioname.md
@@ -6,10 +6,20 @@ image: shioname.png
 start_floor: 17
 end_floor: 19
 agro: Sight
+hp: 6269
+attack_damage: 901
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Salt Stomp
+    potency: 130
+    description: 'instant'
+  - name: Saltstorm
+    potency: 350
+    description: 'telegraphed conal AoE; inflicts accuracy down (30s)'
 ---

--- a/_hoh_011_enemies/shizuku.md
+++ b/_hoh_011_enemies/shizuku.md
@@ -6,6 +6,10 @@ image: shizuku.png
 start_floor: 11
 end_floor: 13
 agro: Proximity
+hp: 5347
+attack_damage: 788
+attack_type: Magic
+attack_name: Water
 vulnerabilities:
   bind: false
   heavy: true

--- a/_hoh_011_enemies/tatsunoko.md
+++ b/_hoh_011_enemies/tatsunoko.md
@@ -6,10 +6,17 @@ image: tatsunoko.png
 start_floor: 16
 end_floor: 19
 agro: Sight
+hp: 6045
+attack_damage: 873
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Hydrate
+    potency: 300
+    description: 'telegraphed conal AoE; inflicts knockback'
 ---

--- a/_hoh_011_enemies/unkiu.md
+++ b/_hoh_011_enemies/unkiu.md
@@ -6,10 +6,20 @@ image: unkiu.png
 start_floor: 14
 end_floor: 16
 agro: Sight
+hp: 5738
+attack_damage: 705
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Scissor Run
+    potency: 45 (x3)
+    description: 'instant 3-hit attack'
+  - name: Flush
+    potency: 300
+    description: 'telegraphed pointblank AoE'
 ---

--- a/_hoh_021_enemies/dhruva.md
+++ b/_hoh_021_enemies/dhruva.md
@@ -5,12 +5,24 @@ image: dhruva.png
 start_floor: 21
 end_floor: 25
 agro: Proximity
+hp: 7165
+attack_damage: 908
+attack_type: Magic
+attack_name: Scathe
 vulnerabilities:
   bind: false
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Aetherial Spark
+    potency: 250
+    description: 'telegraphed line AoE; inflicts bleeding (DoT potency 70,
+    15s)'
+  - name: Tornado
+    potency: 200
+    description: 'telegraphed circle AoE; inflicts knockback'
 notes:
   - 'Can only be slowed with Arm''s Length if transfigured via Pomander of
   Witching since it doesn''t normally do melee auto-attacks'

--- a/_hoh_021_enemies/halgai.md
+++ b/_hoh_021_enemies/halgai.md
@@ -16,5 +16,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Cure
+    potency: n/a
     description: 'heals self for 30% max HP; only used when HP under 35%'
 ---

--- a/_hoh_021_enemies/halgai.md
+++ b/_hoh_021_enemies/halgai.md
@@ -5,10 +5,16 @@ image: halgai.png
 start_floor: 21
 end_floor: 23
 agro: Sight
+hp: 7165
+attack_damage: 872
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Cure
+    description: 'heals self for 30% max HP; only used when HP under 35%'
 ---

--- a/_hoh_021_enemies/hatamoto.md
+++ b/_hoh_021_enemies/hatamoto.md
@@ -6,10 +6,32 @@ image: hatamoto.png
 start_floor: 24
 end_floor: 27
 agro: Proximity
+hp: 7389
+attack_damage: 778
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Tenka Goken
+    potency: 250
+    description: 'untelegraphed conal AoE; inflicts knockback'
+  - name: 雪風
+    potency: 150
+    description: 'instant'
+  - name: 月光
+    potency: 150
+    description: 'instant'
+  - name: 花車
+    potency: 150
+    description: 'instant'
+  - name: 乱れ雪月花
+    potency: 800
+    description: 'enrage'
+notes:
+  - 'Uses each ability in sequence - at low aetherpool levels or when mass
+    pulling the floor, be careful of the final enrage'
 ---

--- a/_hoh_021_enemies/hatamoto.md
+++ b/_hoh_021_enemies/hatamoto.md
@@ -19,16 +19,16 @@ abilities:
   - name: Tenka Goken
     potency: 250
     description: 'untelegraphed conal AoE; inflicts knockback'
-  - name: 雪風
+  - name: '?'
     potency: 150
     description: 'instant'
-  - name: 月光
+  - name: '?'
     potency: 150
     description: 'instant'
-  - name: 花車
+  - name: '?'
     potency: 150
     description: 'instant'
-  - name: 乱れ雪月花
+  - name: '?'
     potency: 800
     description: 'enrage'
 notes:

--- a/_hoh_021_enemies/katasharin.md
+++ b/_hoh_021_enemies/katasharin.md
@@ -18,6 +18,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Crimson Mandate
+    potency: n/a
     description: 'telegraphed cross line AoE; inflicts stacking suppuration
     (max HP -15% and damage taken +15% per stack, 30s)'
 ---

--- a/_hoh_021_enemies/katasharin.md
+++ b/_hoh_021_enemies/katasharin.md
@@ -7,10 +7,17 @@ start_floor: 21
 end_floor: 24
 patrol: true
 agro: Sight
+hp: 7165
+attack_damage: 920
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Crimson Mandate
+    description: 'telegraphed cross line AoE; inflicts stacking suppuration
+    (max HP -15% and damage taken +15% per stack, 30s)'
 ---

--- a/_hoh_021_enemies/keukegen.md
+++ b/_hoh_021_enemies/keukegen.md
@@ -5,10 +5,17 @@ image: keukegen.png
 start_floor: 26
 end_floor: 28
 agro: Sight
+hp: 7389
+attack_damage: 901
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: false
   slow: false
   stun: true
+abilities:
+  - name: Implosive Curse
+    potency: 200
+    description: 'telegraphed conal AoE; inflicts accuracy down (30s)'
 ---

--- a/_hoh_021_enemies/koja.md
+++ b/_hoh_021_enemies/koja.md
@@ -5,10 +5,21 @@ image: koja.png
 start_floor: 27
 end_floor: 29
 agro: Proximity
+hp: 7613
+attack_damage: 642
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: false
+abilities:
+  - name: Lobe Runner
+    potency: 130
+    description: 'instant'
+  - name: 1000 Barbs
+    potency: 1000 damage
+    description: 'telegraphed line AoE; inflicts bleeding (DoT potency 150,
+    30s)'
 ---

--- a/_hoh_021_enemies/menreiki.md
+++ b/_hoh_021_enemies/menreiki.md
@@ -7,10 +7,17 @@ start_floor: 24
 end_floor: 26
 patrol: true
 agro: Sight
+hp: 7389
+attack_damage: 910
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Paralyze III
+    description: 'huge untelegraphed pointblank AoE inflicting paralysis (15s);
+    can be interrupted'
 ---

--- a/_hoh_021_enemies/menreiki.md
+++ b/_hoh_021_enemies/menreiki.md
@@ -18,6 +18,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Paralyze III
+    potency: n/a
     description: 'huge untelegraphed pointblank AoE inflicting paralysis (15s);
     can be interrupted'
 ---

--- a/_hoh_021_enemies/mimic.md
+++ b/_hoh_021_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Malice
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_hoh_021_enemies/mimic.md
+++ b/_hoh_021_enemies/mimic.md
@@ -6,6 +6,9 @@ image: ../mimic_bronze.png
 start_floor: 21
 end_floor: 29
 agro: Proximity
+hp: 10076
+attack_damage: 1215
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Malice
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in bronze chests'

--- a/_hoh_021_enemies/onibi.md
+++ b/_hoh_021_enemies/onibi.md
@@ -6,12 +6,19 @@ image: onibi.png
 start_floor: 21
 end_floor: 22
 agro: Proximity
+hp: 7165
+attack_damage: 908
+attack_type: Magic
+attack_name: Fire
 vulnerabilities:
   bind: false
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Blinding Burst
+    description: '360 degree gaze inflicting accuracy down (20s) - look away'
 notes:
   - 'Can only be slowed with Arm''s Length if transfigured via Pomander of
   Witching since it doesn''t normally do melee auto-attacks'

--- a/_hoh_021_enemies/onibi.md
+++ b/_hoh_021_enemies/onibi.md
@@ -18,6 +18,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Blinding Burst
+    potency: n/a
     description: '360 degree gaze inflicting accuracy down (20s) - look away'
 notes:
   - 'Can only be slowed with Arm''s Length if transfigured via Pomander of

--- a/_hoh_021_enemies/sai_taisui.md
+++ b/_hoh_021_enemies/sai_taisui.md
@@ -5,12 +5,18 @@ image: sai_taisui.png
 start_floor: 22
 end_floor: 25
 agro: Sight
+hp: 7165
+attack_damage: 908
+attack_type: Magic
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: 'Malediction of (?)'
+    description: 'grants damage up (30%, 30s) to self'
 notes:
   - 'Can only be slowed with Arm''s Length if transfigured via Pomander of
   Witching since it doesn''t normally do melee auto-attacks'

--- a/_hoh_021_enemies/sai_taisui.md
+++ b/_hoh_021_enemies/sai_taisui.md
@@ -16,6 +16,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Malediction of (?)'
+    potency: n/a
     description: 'grants damage up (30%, 30s) to self'
 notes:
   - 'Can only be slowed with Arm''s Length if transfigured via Pomander of

--- a/_hoh_021_enemies/tenaga.md
+++ b/_hoh_021_enemies/tenaga.md
@@ -5,10 +5,17 @@ image: tenaga.png
 start_floor: 25
 end_floor: 27
 agro: Sight
+hp: 7389
+attack_damage: 910
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: false
   slow: true
   stun: false
+abilities:
+  - name: Ovation
+    potency: 300
+    description: 'telegraphed line AoE'
 ---

--- a/_hoh_021_enemies/tengu.md
+++ b/_hoh_021_enemies/tengu.md
@@ -19,5 +19,6 @@ abilities:
     potency: 300
     description: 'telegraphed conal AoE'
   - name: Wile of the Tengu
+    potency: n/a
     description: '360 degree gaze inflicting hysteria (3s) - look away'
 ---

--- a/_hoh_021_enemies/tengu.md
+++ b/_hoh_021_enemies/tengu.md
@@ -5,10 +5,19 @@ image: tengu.png
 start_floor: 27
 end_floor: 29
 agro: Sight
+hp: 7613
+attack_damage: 909
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
   sleep: true
   slow: true
   stun: false
+abilities:
+  - name: Isso
+    potency: 300
+    description: 'telegraphed conal AoE'
+  - name: Wile of the Tengu
+    description: '360 degree gaze inflicting hysteria (3s) - look away'
 ---

--- a/_hoh_021_enemies/wanyudo.md
+++ b/_hoh_021_enemies/wanyudo.md
@@ -7,10 +7,17 @@ start_floor: 26
 end_floor: 29
 patrol: true
 agro: Sight
+hp: 7389
+attack_damage: 901
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Midnight Mandate
+    potency: 350
+    description: 'telegraphed circle AoE; inflicts burns (DoT potency 50, 15s)'
 ---

--- a/_hoh_021_enemies/yuki.md
+++ b/_hoh_021_enemies/yuki.md
@@ -17,6 +17,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Enter Night
+    potency: n/a
     description: 'draws players in'
   - name: Shadow Fang
     potency: 250

--- a/_hoh_021_enemies/yuki.md
+++ b/_hoh_021_enemies/yuki.md
@@ -6,10 +6,22 @@ image: yuki.png
 start_floor: 26
 end_floor: 29
 agro: Proximity
+hp: 7389
+attack_damage: 901
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Enter Night
+    description: 'draws players in'
+  - name: Shadow Fang
+    potency: 250
+    description: 'instant conal AoE; used immediately after Enter Night'
+  - name: 'Blood Burst (?)'
+    potency: 600
+    description: 'huge untelegraphed AoE enrage; used 55 seconds after pull'
 ---

--- a/_hoh_031_enemies/ashigaru.md
+++ b/_hoh_031_enemies/ashigaru.md
@@ -5,10 +5,17 @@ image: ashigaru.png
 start_floor: 37
 end_floor: 39
 agro: Sight
+hp: 9404
+attack_damage: 1017
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Bludgeon
+    potency: 50 (x3)
+    description: 'instant 3-hit attack'
 ---

--- a/_hoh_031_enemies/dogu.md
+++ b/_hoh_031_enemies/dogu.md
@@ -5,6 +5,9 @@ image: dogu.png
 start_floor: 36
 end_floor: 39
 agro: Sight
+hp: 9404
+attack_damage: 1002
+attack_type: Magic
 vulnerabilities:
   bind: false
   heavy: true
@@ -13,8 +16,8 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Shifting Light'
-    description: '360 degree gaze that turns you into an otter - look away!
-    If you are already an otter, this will actually change you back'
+    description: '360 degree gaze that turns you into an otter (30s) - look
+    away! If you are already an otter, this will actually change you back'
 notes:
   - 'Can only be slowed with Arm''s Length if transfigured via Pomander of
   Witching since it doesn''t normally do melee auto-attacks'

--- a/_hoh_031_enemies/dogu.md
+++ b/_hoh_031_enemies/dogu.md
@@ -16,6 +16,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Shifting Light'
+    potency: n/a
     description: '360 degree gaze that turns you into an otter (30s) - look
     away! If you are already an otter, this will actually change you back'
 notes:

--- a/_hoh_031_enemies/gedan.md
+++ b/_hoh_031_enemies/gedan.md
@@ -6,10 +6,17 @@ image: gedan.png
 start_floor: 31
 end_floor: 32
 agro: Sight
+hp: 9180
+attack_damage: 967
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Sanguine Bite
+    potency: 130
+    description: 'instant; absorbs 95.5% of damage dealt'
 ---

--- a/_hoh_031_enemies/hanya.md
+++ b/_hoh_031_enemies/hanya.md
@@ -5,10 +5,20 @@ image: hanya.png
 start_floor: 31
 end_floor: 35
 agro: Sight
+hp: 9180
+attack_damage: 955
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Morningstar
+    potency: 130
+    description: 'instant; inflicts concussion (DoT potency 10, 15s)'
+  - name: Auto Crossbow
+    potency: 600
+    description: 'large telegraphed conal AoE'
 ---

--- a/_hoh_031_enemies/harakiri.md
+++ b/_hoh_031_enemies/harakiri.md
@@ -5,6 +5,9 @@ image: harakiri.png
 start_floor: 32
 end_floor: 35
 agro: Sight
+hp: 9180
+attack_damage: 967
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,6 +16,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Harakiri'
-    description: 'Huge, big damage AoE (enrage); long cast; used at low HP or a
-    while after pull (~25 seconds)'
+    potency: 1600
+    description: 'large untelegraphed AoE enrage (smaller than Onmitsu); long
+    cast; can be LoSed. Used at 20% HP or 26 seconds after pull'
 ---

--- a/_hoh_031_enemies/hornbill.md
+++ b/_hoh_031_enemies/hornbill.md
@@ -6,10 +6,21 @@ image: hornbill.png
 start_floor: 31
 end_floor: 33
 agro: Sight
+hp: 9180
+attack_damage: 955
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Breakbeak
+    potency: 130
+    description: 'instant'
+  - name: Gust
+    potency: 500
+    description: 'telegraphed circle AoE; inflicts windburn (DoT potency 50,
+    30s)'
 ---

--- a/_hoh_031_enemies/kiyofusa.md
+++ b/_hoh_031_enemies/kiyofusa.md
@@ -5,6 +5,9 @@ image: kiyofusa.png
 start_floor: 36
 end_floor: 39
 agro: Sight
+hp: 9404
+attack_damage: 1002
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -12,7 +15,8 @@ vulnerabilities:
   slow: true
   stun: false
 abilities:
-  - name: 'Helm Crack'
-    description: 'shared damage AoE and gap-closer; little damage, even if
-    solo; can be LoS''d'
+  - name: Helm Crack
+    potency: 300
+    description: 'shared damage AoE and gap closer; can be LoSed. Fairly weak
+    for a shared damage AoE (can be taken solo even by DPS/healers)'
 ---

--- a/_hoh_031_enemies/mimic.md
+++ b/_hoh_031_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Malice
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_hoh_031_enemies/mimic.md
+++ b/_hoh_031_enemies/mimic.md
@@ -6,6 +6,9 @@ image: ../mimic_silver.png
 start_floor: 31
 end_floor: 39
 agro: Proximity
+hp: 12539
+attack_damage: 1363
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Malice
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in silver chests'

--- a/_hoh_031_enemies/mokin.md
+++ b/_hoh_031_enemies/mokin.md
@@ -21,6 +21,6 @@ abilities:
     description: 'telegraphed pointblank AoE; inflicts bind (10s)'
   - name: 'Bloodcurdling Cry (?)'
     potency: n/a
-    description: 'telegraphed pointblank AoE. Seems to have no effect on
-    players (shows a debuff animation but no debuffs are applied)'
+    description: 'telegraphed pointblank AoE; reduces the remaining time on
+    all buffs (including food) by half'
 ---

--- a/_hoh_031_enemies/mokin.md
+++ b/_hoh_031_enemies/mokin.md
@@ -6,10 +6,19 @@ image: mokin.png
 start_floor: 36
 end_floor: 38
 agro: Sight
+hp: 9404
+attack_damage: 993
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Yolk Shower
+    description: 'telegraphed pointblank AoE; inflicts bind (10s)'
+  - name: 'Bloodcurdling Cry (?)'
+    description: 'telegraphed pointblank AoE. Seems to have no effect on
+    players (shows a debuff animation but no debuffs are applied)'
 ---

--- a/_hoh_031_enemies/mokin.md
+++ b/_hoh_031_enemies/mokin.md
@@ -17,8 +17,10 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Yolk Shower
+    potency: n/a
     description: 'telegraphed pointblank AoE; inflicts bind (10s)'
   - name: 'Bloodcurdling Cry (?)'
+    potency: n/a
     description: 'telegraphed pointblank AoE. Seems to have no effect on
     players (shows a debuff animation but no debuffs are applied)'
 ---

--- a/_hoh_031_enemies/moko.md
+++ b/_hoh_031_enemies/moko.md
@@ -6,10 +6,17 @@ image: moko.png
 start_floor: 35
 end_floor: 37
 agro: Sight
+hp: 9404
+attack_damage: 993
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Catching Claws
+    potency: 130
+    description: 'instant'
 ---

--- a/_hoh_031_enemies/onmitsu.md
+++ b/_hoh_031_enemies/onmitsu.md
@@ -6,6 +6,9 @@ image: onmitsu.png
 start_floor: 34
 end_floor: 37
 agro: Sight
+hp: 9180
+attack_damage: 973
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,7 +17,11 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Juji Shuriken'
-    description: 'telegraphed line AoE'
+    potency: 550
+    description: 'telegraphed line AoE; inflicts flesh wound (DoT potency 50,
+    30s)'
   - name: 'Harakiri'
-    description: 'Huge, big damage AoE (enrage); long cast; used at low HP'
+    potency: 1500
+    description: 'huge untelegraphed AoE enrage; long cast; can be LoSed. Used
+    at 10% HP'
 ---

--- a/_hoh_031_enemies/onmitsu_patrol.md
+++ b/_hoh_031_enemies/onmitsu_patrol.md
@@ -7,6 +7,9 @@ start_floor: 31
 end_floor: 34
 patrol: true
 agro: Sight
+hp: 9180
+attack_damage: 967
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,8 +17,15 @@ vulnerabilities:
   slow: true
   stun: true
 abilities:
+  - name: 'Issen'
+    potency: 120
+    description: 'instant'
   - name: 'Juji Shuriken'
-    description: 'telegraphed line AoE'
+    potency: 550
+    description: 'telegraphed line AoE; inflicts flesh wound (DoT potency 50,
+    30s)'
   - name: 'Harakiri'
-    description: 'Huge, big damage AoE (enrage); long cast; used at low HP'
+    potency: 1500
+    description: 'huge untelegraphed AoE enrage; long cast; can be LoSed. Used
+    at 10% HP'
 ---

--- a/_hoh_031_enemies/shishi.md
+++ b/_hoh_031_enemies/shishi.md
@@ -6,10 +6,20 @@ image: shishi.png
 start_floor: 37
 end_floor: 39
 agro: Sight
+hp: 9404
+attack_damage: 1017
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: true
   slow: true
   stun: true
+abilities:
+  - name: Pounce
+    potency: 120
+    description: 'instant'
+  - name: Cry
+    potency: 500
+    description: 'large telegraphed pointblank AoE; can be LoSed'
 ---

--- a/_hoh_031_enemies/vanara.md
+++ b/_hoh_031_enemies/vanara.md
@@ -6,6 +6,9 @@ start_floor: 34
 end_floor: 36
 patrol: true
 agro: Sight
+hp: 9180
+attack_damage: 973
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,7 +16,12 @@ vulnerabilities:
   slow: true
   stun: true
 abilities:
-  - name: '?'
-    description: 'non-telegraphed conal AoE; it raises a hand to indicate it''s
+  - name: 'Butcher Claw (?)'
+    potency: 400
+    description: 'untelegraphed conal AoE; it raises a hand to indicate it''s
     going to do this'
+  - name: 'Ripper Claw (?)'
+    potency: 400
+    description: 'untelegraphed conal AoE immediately following Butcher Claw
+    (so don't move back in front right away)'
 ---

--- a/_hoh_031_enemies/vanara.md
+++ b/_hoh_031_enemies/vanara.md
@@ -23,5 +23,5 @@ abilities:
   - name: 'Ripper Claw (?)'
     potency: 400
     description: 'untelegraphed conal AoE immediately following Butcher Claw
-    (so don't move back in front right away)'
+    (so don''t move back in front right away)'
 ---

--- a/_hoh_041_enemies/aka_ishi.md
+++ b/_hoh_041_enemies/aka_ishi.md
@@ -6,10 +6,17 @@ image: aka_ishi.png
 start_floor: 46
 end_floor: 49
 agro: Sight
+hp: 10748
+attack_damage: 1136
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Wild Horn
+    potency: 600
+    description: 'telegraphed conal AoE; inflicts knockback'
 ---

--- a/_hoh_041_enemies/dhara.md
+++ b/_hoh_041_enemies/dhara.md
@@ -5,10 +5,20 @@ image: dhara.png
 start_floor: 41
 end_floor: 45
 agro: Sight
+hp: 10524
+attack_damage: 972
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: false
   slow: true
   stun: false
+abilities:
+  - name: Straight Punch
+    potency: 120
+    description: 'instant'
+  - name: Plain Pound
+    potency: 400
+    description: 'telegraphed pointblank AoE'
 ---

--- a/_hoh_041_enemies/ganseki.md
+++ b/_hoh_041_enemies/ganseki.md
@@ -6,6 +6,10 @@ image: ganseki.png
 start_floor: 41
 end_floor: 43
 agro: Proximity
+hp: 10524
+attack_damage: 1013
+attack_type: Magic
+attack_name: Stone
 vulnerabilities:
   bind: false
   heavy: true

--- a/_hoh_041_enemies/iseki_green.md
+++ b/_hoh_041_enemies/iseki_green.md
@@ -6,10 +6,21 @@ image: iseki_green.png
 start_floor: 47
 end_floor: 49
 agro: Sight
+hp: 10972
+attack_damage: 1136
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Carpomission
+    potency: 130
+    description: 'instant'
+  - name: Isle Drop
+    potency: 600
+    description: 'telegraphed circle AoE; inflicts stun (5s); also used out of
+    battle'
 ---

--- a/_hoh_041_enemies/iseki_purple.md
+++ b/_hoh_041_enemies/iseki_purple.md
@@ -6,10 +6,20 @@ image: iseki_purple.png
 start_floor: 46
 end_floor: 48
 agro: Sight
+hp: 10748
+attack_damage: 1002
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Carpomission
+    potency: 130
+    description: 'instant'
+  - name: Neck Splinter
+    potency: 600
+    description: 'telegraphed pointblank AoE'
 ---

--- a/_hoh_041_enemies/kuro_usagi.md
+++ b/_hoh_041_enemies/kuro_usagi.md
@@ -7,10 +7,21 @@ start_floor: 41
 end_floor: 44
 patrol: true
 agro: Sight
+hp: 10524
+attack_damage: 972
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Rockslide
+    potency: 600
+    description: 'telegraphed line AoE'
+  - name: 'Heart Gleam (?)'
+    potency: 600
+    description: 'telegraphed circle AoE; inflicts burns (DoT potency 100,
+    15s)'
 ---

--- a/_hoh_041_enemies/mimic.md
+++ b/_hoh_041_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Malice
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_hoh_041_enemies/mimic.md
+++ b/_hoh_041_enemies/mimic.md
@@ -6,6 +6,9 @@ image: ../mimic_silver.png
 start_floor: 41
 end_floor: 49
 agro: Proximity
+hp: 14554
+attack_damage: 1509
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Malice
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in silver chests'

--- a/_hoh_041_enemies/mizumimizu.md
+++ b/_hoh_041_enemies/mizumimizu.md
@@ -7,6 +7,9 @@ start_floor: 46
 end_floor: 49
 patrol: true
 agro: Sound
+hp: 10748
+attack_damage: 1136
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -14,9 +17,15 @@ vulnerabilities:
   slow: true
   stun: true
 abilities:
-  - name: '?'
-    description: 'draw-in that applies heavy; used ~30s after pull'
-  - name: '?'
-    description: 'telegraphed pointblank AoE for big damage (enrage); used
-    immediately after draw-in'
+  - name: Sand Pillar
+    potency: 30
+    description: 'instant'
+  - name: Bottomless Desert
+    potency: 20
+    description: 'quick huge pointblank AoE; draws players in and inflicts
+    stun (5s). Used 30 seconds after pull and then at 60-second intervals'
+  - name: Temblor
+    potency: 1000
+    description: 'instant pointblank AoE (enrage); used immediately after
+    Bottomless Desert'
 ---

--- a/_hoh_041_enemies/monoiwa.md
+++ b/_hoh_041_enemies/monoiwa.md
@@ -6,10 +6,17 @@ image: monoiwa.png
 start_floor: 47
 end_floor: 49
 agro: Sight
+hp: 10972
+attack_damage: 1136
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Boulder Toss
+    potency: 160 (x3)
+    description: 'ranged attack; used 3 times in a row on the same player'
 ---

--- a/_hoh_041_enemies/saikoro_aero.md
+++ b/_hoh_041_enemies/saikoro_aero.md
@@ -3,13 +3,20 @@ name: Heavenly Saikoro
 nickname: Saikoro
 family: Urolith
 image: saikoro.png
-start_floor: 41
+start_floor: 44
 end_floor: 47
 agro: Sight
+hp: 10748
+attack_damage: 1002
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Ancient Aero
+    potency: 120
+    description: 'instant (possibly line AoE?)'
 ---

--- a/_hoh_041_enemies/saikoro_tornado.md
+++ b/_hoh_041_enemies/saikoro_tornado.md
@@ -1,0 +1,22 @@
+---
+name: Heavenly Saikoro
+nickname: Saikoro
+family: Urolith
+image: saikoro.png
+start_floor: 41
+end_floor: 43
+agro: Sight
+hp: 10524
+attack_damage: 973
+attack_type: Physical
+vulnerabilities:
+  bind: false
+  heavy: true
+  sleep: false
+  slow: true
+  stun: true
+abilities:
+  - name: Tornado
+    potency: 130
+    description: 'instant (possibly circle AoE?)'
+---

--- a/_hoh_041_enemies/sekiban.md
+++ b/_hoh_041_enemies/sekiban.md
@@ -5,12 +5,20 @@ image: sekiban.png
 start_floor: 44
 end_floor: 47
 agro: Sight
+hp: 10748
+attack_damage: 1044
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: false
   slow: true
   stun: false
-notes:
-  - 'Have an enrage'
+abilities:
+  - name: Epigraph
+    potency: 600
+    description: 'telegraphed long line AoE'
+  - name: 'Epigraph Quake (?)'
+    potency: 1000
+    description: 'huge AoE enrage; used 25 seconds after pull'
 ---

--- a/_hoh_041_enemies/sekizo.md
+++ b/_hoh_041_enemies/sekizo.md
@@ -6,10 +6,20 @@ image: sekizo.png
 start_floor: 42
 end_floor: 45
 agro: Sight
+hp: 10748
+attack_damage: 1086
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: Plaincracker
+    potency: 600
+    description: 'telegraphed pointblank AoE'
+  - name: Rockslide
+    potency: 600
+    description: 'telegraphed line AoE'
 ---

--- a/_hoh_041_enemies/sekizo_patrol.md
+++ b/_hoh_041_enemies/sekizo_patrol.md
@@ -7,10 +7,19 @@ start_floor: 44
 end_floor: 46
 patrol: true
 agro: Sight
+hp: 10748
+attack_damage: 1122
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
   sleep: false
   slow: true
   stun: false
+abilities:
+  - name: 'Magnetism (?)'
+    description: 'draws players in'
+  - name: Plaincracker
+    potency: 750
+    description: 'telegraphed pointblank AoE'
 ---

--- a/_hoh_041_enemies/sekizo_patrol.md
+++ b/_hoh_041_enemies/sekizo_patrol.md
@@ -18,6 +18,7 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Magnetism (?)'
+    potency: n/a
     description: 'draws players in'
   - name: Plaincracker
     potency: 750

--- a/_hoh_051_enemies/dokyu.md
+++ b/_hoh_051_enemies/dokyu.md
@@ -17,10 +17,8 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Incinerate'
-    potency: ?
     description: 'telegraphed conal AoE'
   - name: 'Wrecking Ball'
-    potency: ?
     description: 'telegraphed circle AoE; used immediately after Incinerate'
 job_specifics:
   MCH:

--- a/_hoh_051_enemies/dokyu.md
+++ b/_hoh_051_enemies/dokyu.md
@@ -6,6 +6,9 @@ image: dokyu.png
 start_floor: 56
 end_floor: 59
 agro: Sight
+hp: 26198
+attack_damage: 2720
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,8 +17,10 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Incinerate'
+    potency: ?
     description: 'telegraphed conal AoE'
   - name: 'Wrecking Ball'
+    potency: ?
     description: 'telegraphed circle AoE; used immediately after Incinerate'
 job_specifics:
   MCH:

--- a/_hoh_051_enemies/gowan.md
+++ b/_hoh_051_enemies/gowan.md
@@ -5,6 +5,9 @@ image: gowan.png
 start_floor: 57
 end_floor: 59
 agro: Sight
+hp: 23063
+attack_damage: 2167
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,10 +16,12 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Electromagnetism'
+    potency: 50
     description: 'short-range draw-in; can be interrupted'
   - name: 'Headspin'
+    potency: 120
     description: 'instant pointblank AoE; used immediately after
-    Electormagnetism'
+    Electromagnetism'
 job_specifics:
   MCH:
     difficulty: Easy

--- a/_hoh_051_enemies/kamakiri.md
+++ b/_hoh_051_enemies/kamakiri.md
@@ -6,6 +6,9 @@ image: kamakiri.png
 start_floor: 51
 end_floor: 53
 agro: Sound
+hp: 19928
+attack_damage: 2139
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,7 +17,8 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Standing Chine'
-    description: 'attack that inflicts flesh wound (DoT)'
+    potency: 30
+    description: 'instant; inflicts flesh wound (DoT potency 20, 30s)'
 job_specifics:
   MCH:
     difficulty: Easy

--- a/_hoh_051_enemies/kamanari.md
+++ b/_hoh_051_enemies/kamanari.md
@@ -5,6 +5,9 @@ image: kamanari.png
 start_floor: 51
 end_floor: 53
 agro: Sound
+hp: 19481
+attack_damage: 2089
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -12,7 +15,7 @@ vulnerabilities:
   slow: true
   stun: true
 notes:
-  - 'auto-attacks inflict a 6s stacking vulnerability up'
+  - 'auto-attacks inflict stacking vulnerability up (5% per stack, 6s)'
 job_specifics:
   MCH:
     difficulty: Easy

--- a/_hoh_051_enemies/karakuri.md
+++ b/_hoh_051_enemies/karakuri.md
@@ -6,6 +6,9 @@ image: karakuri.png
 start_floor: 56
 end_floor: 58
 agro: Sight
+hp: 22392
+attack_damage: 2210
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true

--- a/_hoh_051_enemies/kongorei.md
+++ b/_hoh_051_enemies/kongorei.md
@@ -6,6 +6,10 @@ image: kongorei.png
 start_floor: 52
 end_floor: 55
 agro: Sight
+hp: 19928
+attack_damage: 2056
+attack_type: Magic
+attack_name: Cover Fire
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,11 +17,11 @@ vulnerabilities:
   slow: true
   stun: true
 abilities:
-  - name: 'Cover Fire'
-    description: 'ranged attack used instead of auto-attacks'
   - name: 'Assault Cannon'
+    potency: ?
     description: 'telegraphed line AoE'
   - name: '?'
+    potency: ?
     description: 'enrage wipe (after 30 seconds?)'
 notes:
   - 'Can only be slowed with Arm''s Length if transfigured via Pomander of

--- a/_hoh_051_enemies/kongorei.md
+++ b/_hoh_051_enemies/kongorei.md
@@ -18,10 +18,8 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Assault Cannon'
-    potency: ?
     description: 'telegraphed line AoE'
   - name: '?'
-    potency: ?
     description: 'enrage wipe (after 30 seconds?)'
 notes:
   - 'Can only be slowed with Arm''s Length if transfigured via Pomander of

--- a/_hoh_051_enemies/maruishi.md
+++ b/_hoh_051_enemies/maruishi.md
@@ -6,6 +6,7 @@ image: maruishi.png
 start_floor: 54
 end_floor: 56
 agro: Proximity
+hp: 21496
 vulnerabilities:
   bind: false
   heavy: true
@@ -14,6 +15,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Auto-cannons'
+    potency: ?
     description: 'telegraphed line AoE'
 notes:
   - 'Doesn''t have auto-attacks'

--- a/_hoh_051_enemies/maruishi.md
+++ b/_hoh_051_enemies/maruishi.md
@@ -15,7 +15,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Auto-cannons'
-    potency: ?
     description: 'telegraphed line AoE'
 notes:
   - 'Doesn''t have auto-attacks'

--- a/_hoh_051_enemies/mimic.md
+++ b/_hoh_051_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Malice
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_hoh_051_enemies/mimic.md
+++ b/_hoh_051_enemies/mimic.md
@@ -6,6 +6,9 @@ image: ../mimic_silver.png
 start_floor: 51
 end_floor: 59
 agro: Proximity
+hp: 38738
+attack_damage: 3624
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Malice
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in silver chests'

--- a/_hoh_051_enemies/naga.md
+++ b/_hoh_051_enemies/naga.md
@@ -18,6 +18,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Calcifying Mist'
+    potency: n/a
     description: 'conal gaze; inflicts petrify - look away, get behind, or get
     away'
   - name: 'Baleful Roar'

--- a/_hoh_051_enemies/naga.md
+++ b/_hoh_051_enemies/naga.md
@@ -7,6 +7,9 @@ start_floor: 51
 end_floor: 54
 patrol: true
 agro: Sight
+hp: 20824
+attack_damage: 2290
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -15,11 +18,12 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Calcifying Mist'
-    description: 'conal gaze causing petrification - look away, get behind, or
-    get away'
+    description: 'conal gaze; inflicts petrify - look away, get behind, or get
+    away'
   - name: 'Baleful Roar'
-    description: 'non-telegraphed huge pointblank AoE - big damage; can be
-    interrupted or LoS''d'
+    potency: 450
+    description: 'untelegraphed huge pointblank AoE; can be interrupted or
+    LoSed'
 job_specifics:
   MCH:
     difficulty: Easy

--- a/_hoh_051_enemies/rachimonai.md
+++ b/_hoh_051_enemies/rachimonai.md
@@ -5,6 +5,10 @@ image: rachimonai.png
 start_floor: 57
 end_floor: 59
 agro: Proximity
+hp: 25302
+attack_damage: 2090
+attack_type: Magic
+attack_name: Aetherochemical Laser
 vulnerabilities:
   bind: false
   heavy: false
@@ -12,9 +16,8 @@ vulnerabilities:
   slow: true
   stun: false
 abilities:
-  - name: 'Aetherochemical Laser'
-    description: 'ranged attack used instead of auto-attacks'
   - name: 'Passive Infrared Guidance System'
+    potency: 130
     description: 'instant circle AoE; also used out of combat'
 notes:
   - 'Can only be slowed with Arm''s Length if transfigured via Pomander of

--- a/_hoh_051_enemies/shabti.md
+++ b/_hoh_051_enemies/shabti.md
@@ -5,6 +5,9 @@ image: shabti.png
 start_floor: 56
 end_floor: 59
 agro: Sight
+hp: 24631
+attack_damage: 2461
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,6 +16,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Spellsword'
+    potency: ?
     description: 'telegraphed conal AoE'
 job_specifics:
   MCH:

--- a/_hoh_051_enemies/shabti.md
+++ b/_hoh_051_enemies/shabti.md
@@ -16,7 +16,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Spellsword'
-    potency: ?
     description: 'telegraphed conal AoE'
 job_specifics:
   MCH:

--- a/_hoh_051_enemies/tesso.md
+++ b/_hoh_051_enemies/tesso.md
@@ -20,7 +20,6 @@ abilities:
     potency: 50
     description: 'instant; inflicts stab wound (DoT potency 60, 30s)'
   - name: 'The Hand'
-    potency: ?
     description: 'telegraphed conal AoE'
 job_specifics:
   MCH:

--- a/_hoh_051_enemies/tesso.md
+++ b/_hoh_051_enemies/tesso.md
@@ -6,6 +6,9 @@ image: tesso.png
 start_floor: 54
 end_floor: 57
 agro: Sight
+hp: 21496
+attack_damage: 1930
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -14,8 +17,10 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Shred'
-    description: 'inflicts Stab Wound (DoT)'
+    potency: 50
+    description: 'instant; inflicts stab wound (DoT potency 60, 30s)'
   - name: 'The Hand'
+    potency: ?
     description: 'telegraphed conal AoE'
 job_specifics:
   MCH:

--- a/_hoh_051_enemies/tetsu_kyojin.md
+++ b/_hoh_051_enemies/tetsu_kyojin.md
@@ -18,10 +18,8 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Grand Strike'
-    potency: ?
     description: 'telegraphed line AoE'
   - name: 'Magitek Ray'
-    potency: ?
     description: 'telegraphed circle AoE; used immediately after Grand Strike'
 job_specifics:
   MCH:

--- a/_hoh_051_enemies/tetsu_kyojin.md
+++ b/_hoh_051_enemies/tetsu_kyojin.md
@@ -7,6 +7,9 @@ start_floor: 54
 end_floor: 56
 patrol: true
 agro: Sight
+hp: 25079
+attack_damage: 2665
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,10 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Grand Strike'
+    potency: ?
     description: 'telegraphed line AoE'
   - name: 'Magitek Ray'
+    potency: ?
     description: 'telegraphed circle AoE; used immediately after Grand Strike'
 job_specifics:
   MCH:

--- a/_hoh_051_enemies/tokagekiba.md
+++ b/_hoh_051_enemies/tokagekiba.md
@@ -6,6 +6,9 @@ image: tokagekiba.png
 start_floor: 51
 end_floor: 55
 agro: Sight
+hp: 21272
+attack_damage: 2382
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: false
@@ -14,8 +17,9 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Berserk'
-    description: 'grants attack up'
+    description: 'grants attack up (50%, 20s) to self'
   - name: 'Rear'
+    potency: 750
     description: 'telegraphed pointblank AoE'
 job_specifics:
   MCH:

--- a/_hoh_051_enemies/tokagekiba.md
+++ b/_hoh_051_enemies/tokagekiba.md
@@ -17,6 +17,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Berserk'
+    potency: n/a
     description: 'grants attack up (50%, 20s) to self'
   - name: 'Rear'
     potency: 750

--- a/_hoh_061_enemies/chizakura.md
+++ b/_hoh_061_enemies/chizakura.md
@@ -18,10 +18,8 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Creeping Ivy'
-    potency: ?
     description: 'telegraphed conal AoE'
   - name: 'Entangle'
-    potency: ?
     description: 'telegraphed circle AoE'
 job_specifics:
   DRK:

--- a/_hoh_061_enemies/chizakura.md
+++ b/_hoh_061_enemies/chizakura.md
@@ -7,6 +7,9 @@ start_floor: 66
 end_floor: 69
 patrol: true
 agro: Sight
+hp: 38000
+attack_damage: 3738
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,10 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Creeping Ivy'
+    potency: ?
     description: 'telegraphed conal AoE'
   - name: 'Entangle'
+    potency: ?
     description: 'telegraphed circle AoE'
 job_specifics:
   DRK:

--- a/_hoh_061_enemies/doguzeri.md
+++ b/_hoh_061_enemies/doguzeri.md
@@ -18,7 +18,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Swift Sough'
-    potency: ?
     description: 'telegraphed conal AoE'
 notes:
   - 'Can only be slowed with Arm''s Length if transfigured via Pomander of

--- a/_hoh_061_enemies/doguzeri.md
+++ b/_hoh_061_enemies/doguzeri.md
@@ -6,6 +6,10 @@ image: doguzeri.png
 start_floor: 64
 end_floor: 67
 agro: Sound
+hp: 35000
+attack_damage: 3259
+attack_type: Physical
+attack_name: Seedvolley
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,6 +18,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Swift Sough'
+    potency: ?
     description: 'telegraphed conal AoE'
 notes:
   - 'Can only be slowed with Arm''s Length if transfigured via Pomander of

--- a/_hoh_061_enemies/hashiri_dokoro.md
+++ b/_hoh_061_enemies/hashiri_dokoro.md
@@ -17,9 +17,9 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Atropine Spore'
-    potency: ?
     description: 'telegraphed huge donut AoE'
   - name: 'Frond Fatale'
+    potency: n/a
     description: '360 degree gaze'
   - name: 'Soul Vacuum'
     potency: 50?

--- a/_hoh_061_enemies/hashiri_dokoro.md
+++ b/_hoh_061_enemies/hashiri_dokoro.md
@@ -6,6 +6,9 @@ image: hashiri_dokoro.png
 start_floor: 66
 end_floor: 69
 agro: Sight
+hp: 40000
+attack_damage: 3945
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,10 +17,12 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Atropine Spore'
+    potency: ?
     description: 'telegraphed huge donut AoE'
   - name: 'Frond Fatale'
     description: '360 degree gaze'
-  - name: 'Soul Vaccuum'
+  - name: 'Soul Vacuum'
+    potency: 50?
     description: 'untelegraphed huge pointblank AoE; instant death if you got
     hit by Frond Fatale'
 job_specifics:

--- a/_hoh_061_enemies/iwamushi.md
+++ b/_hoh_061_enemies/iwamushi.md
@@ -5,6 +5,9 @@ image: iwamushi.png
 start_floor: 62
 end_floor: 65
 agro: Sight
+hp: 34035
+attack_damage: 3204
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,6 +16,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Shatter'
+    potency: ?
     description: 'telegraphed pointblank AoE'
 job_specifics:
   DRK:

--- a/_hoh_061_enemies/iwamushi.md
+++ b/_hoh_061_enemies/iwamushi.md
@@ -16,7 +16,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Shatter'
-    potency: ?
     description: 'telegraphed pointblank AoE'
 job_specifics:
   DRK:

--- a/_hoh_061_enemies/jellyfish.md
+++ b/_hoh_061_enemies/jellyfish.md
@@ -16,7 +16,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Irritating Tendrils'
-    potency: ?
     description: 'telegraphed short line AoE'
   - name: 'Numbing Tendrils'
     potency: 750?

--- a/_hoh_061_enemies/jellyfish.md
+++ b/_hoh_061_enemies/jellyfish.md
@@ -5,6 +5,9 @@ image: jellyfish.png
 start_floor: 63
 end_floor: 67
 agro: Sight
+hp: 35000
+attack_damage: 3302
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -13,9 +16,11 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Irritating Tendrils'
+    potency: ?
     description: 'telegraphed short line AoE'
   - name: 'Numbing Tendrils'
-    description: 'telegraphed short line AoE, causes paralyze'
+    potency: 750?
+    description: 'telegraphed short line AoE; inflicts paralysis'
 notes:
   - 'Its line AoEs are quick, so be ready to move fast'
 job_specifics:

--- a/_hoh_061_enemies/jubokko.md
+++ b/_hoh_061_enemies/jubokko.md
@@ -7,6 +7,9 @@ start_floor: 61
 end_floor: 64
 patrol: true
 agro: Sight
+hp: 36000
+attack_damage: 3560
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,6 +18,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'The Wood Remembers'
+    potency: ?
     description: 'telegraphed conal AoE'
   - name: 'Stoneskin'
     description: 'grants stoneskin; only used on other nearby enemies'

--- a/_hoh_061_enemies/jubokko.md
+++ b/_hoh_061_enemies/jubokko.md
@@ -18,9 +18,9 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'The Wood Remembers'
-    potency: ?
     description: 'telegraphed conal AoE'
   - name: 'Stoneskin'
+    potency: n/a
     description: 'grants stoneskin; only used on other nearby enemies'
 job_specifics:
   DRK:

--- a/_hoh_061_enemies/kosodegai.md
+++ b/_hoh_061_enemies/kosodegai.md
@@ -17,7 +17,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Palsynyxis'
-    potency: ?
     description: 'telegraphed conal AoE'
 job_specifics:
   DRK:

--- a/_hoh_061_enemies/kosodegai.md
+++ b/_hoh_061_enemies/kosodegai.md
@@ -6,6 +6,9 @@ image: kosodegai.png
 start_floor: 65
 end_floor: 68
 agro: Sight
+hp: 36000
+attack_damage: 3340
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,6 +17,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Palsynyxis'
+    potency: ?
     description: 'telegraphed conal AoE'
 job_specifics:
   DRK:

--- a/_hoh_061_enemies/mannenso.md
+++ b/_hoh_061_enemies/mannenso.md
@@ -5,6 +5,9 @@ image: mannenso.png
 start_floor: 61
 end_floor: 63
 agro: Sight
+hp: 35000
+attack_damage: 2868
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,9 +16,11 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Adventitious Lash'
-    description: 'tankbuster'
-notes:
-  - 'auto-attacks inflict a 10s stacking vulnerability up'
+    potency: 120
+    description: 'instant'
+  - name: 'Ballistic Ball (?)'
+    description: 'instant; inflicts stacking vulnerability up (5%? per stack,
+    10s)'
 job_specifics:
   DRK:
     difficulty: Easy

--- a/_hoh_061_enemies/mannenso.md
+++ b/_hoh_061_enemies/mannenso.md
@@ -19,6 +19,7 @@ abilities:
     potency: 120
     description: 'instant'
   - name: 'Ballistic Ball (?)'
+    potency: n/a
     description: 'instant; inflicts stacking vulnerability up (5%? per stack,
     10s)'
 job_specifics:

--- a/_hoh_061_enemies/mimic.md
+++ b/_hoh_061_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Malice
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_hoh_061_enemies/mimic.md
+++ b/_hoh_061_enemies/mimic.md
@@ -6,6 +6,9 @@ image: ../mimic_gold.png
 start_floor: 61
 end_floor: 69
 agro: Proximity
+hp: 45000
+attack_damage: 5258
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Malice
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_hoh_061_enemies/morbol.md
+++ b/_hoh_061_enemies/morbol.md
@@ -6,6 +6,9 @@ start_floor: 64
 end_floor: 66
 patrol: true
 agro: Sight
+hp: 38000
+attack_damage: 3710
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,8 +17,10 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Quaver'
+    potency: ?
     description: 'telegraphed pointblank AoE'
   - name: 'Offal Breath'
+    potency: ?
     description: 'telegraphed circle AoE'
 job_specifics:
   DRK:

--- a/_hoh_061_enemies/morbol.md
+++ b/_hoh_061_enemies/morbol.md
@@ -17,10 +17,8 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Quaver'
-    potency: ?
     description: 'telegraphed pointblank AoE'
   - name: 'Offal Breath'
-    potency: ?
     description: 'telegraphed circle AoE'
 job_specifics:
   DRK:

--- a/_hoh_061_enemies/onryo.md
+++ b/_hoh_061_enemies/onryo.md
@@ -5,6 +5,9 @@ image: onryo.png
 start_floor: 61
 end_floor: 65
 agro: Proximity
+hp: 35000
+attack_damage: 3335
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -13,8 +16,10 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Tentacle'
-    description: 'applies concussion (DoT)'
+    potency: 75?
+    description: 'instant; inflicts concussion (DoT potency 50, 15s)'
   - name: 'Accursed Sigh'
+    potency: ?
     description: 'telegraphed conal AoE'
 job_specifics:
   DRK:

--- a/_hoh_061_enemies/onryo.md
+++ b/_hoh_061_enemies/onryo.md
@@ -19,7 +19,6 @@ abilities:
     potency: 75?
     description: 'instant; inflicts concussion (DoT potency 50, 15s)'
   - name: 'Accursed Sigh'
-    potency: ?
     description: 'telegraphed conal AoE'
 job_specifics:
   DRK:

--- a/_hoh_061_enemies/penghou.md
+++ b/_hoh_061_enemies/penghou.md
@@ -6,6 +6,9 @@ image: penghou.png
 start_floor: 67
 end_floor: 69
 agro: Sight
+hp: 35000
+attack_damage: 3295
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,6 +17,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Gold Dust'
+    potency: ?
     description: 'telegraphed circle AoE'
 job_specifics:
   DRK:

--- a/_hoh_061_enemies/penghou.md
+++ b/_hoh_061_enemies/penghou.md
@@ -17,7 +17,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Gold Dust'
-    potency: ?
     description: 'telegraphed circle AoE'
 job_specifics:
   DRK:

--- a/_hoh_061_enemies/shitaibana.md
+++ b/_hoh_061_enemies/shitaibana.md
@@ -19,6 +19,7 @@ abilities:
     potency: 120?
     description: 'instant'
   - name: 'Acid Mist (?)'
+    potency: n/a
     description: 'untelegraphed instant conal AoE; inflicts poison'
 job_specifics:
   DRK:

--- a/_hoh_061_enemies/shitaibana.md
+++ b/_hoh_061_enemies/shitaibana.md
@@ -5,6 +5,9 @@ image: shitaibana.png
 start_floor: 66
 end_floor: 69
 agro: Sight
+hp: 36000
+attack_damage: 3115
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,9 +16,10 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Bloody Caress'
-    description: 'cleave'
-  - name: '?'
-    description: 'untelegraphed instant conal AoE inflicting poison'
+    potency: 120?
+    description: 'instant'
+  - name: 'Acid Mist (?)'
+    description: 'untelegraphed instant conal AoE; inflicts poison'
 job_specifics:
   DRK:
     difficulty: Easy

--- a/_hoh_061_enemies/wakakusa.md
+++ b/_hoh_061_enemies/wakakusa.md
@@ -16,7 +16,8 @@ vulnerabilities:
   slow: true
   stun: true
 notes:
-  - 'auto-attacks inflict stacking poison (10% per stack, max 8 stacks, 30s)'
+  - 'auto-attacks inflict stacking poison (DoT potency 10 per stack, max 8
+    stacks, 30s)'
 job_specifics:
   DRK:
     difficulty: Medium

--- a/_hoh_061_enemies/wakakusa.md
+++ b/_hoh_061_enemies/wakakusa.md
@@ -6,6 +6,9 @@ image: wakakusa.png
 start_floor: 61
 end_floor: 63
 agro: Sound
+hp: 34000
+attack_damage: 2940
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,7 +16,7 @@ vulnerabilities:
   slow: true
   stun: true
 notes:
-  - 'auto-attacks inflict a 30s stacking poison'
+  - 'auto-attacks inflict stacking poison (10% per stack, max 8 stacks, 30s)'
 job_specifics:
   DRK:
     difficulty: Medium

--- a/_hoh_071_enemies/hyoga.md
+++ b/_hoh_071_enemies/hyoga.md
@@ -18,10 +18,8 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Absolute Zero'
-    potency: ?
     description: 'telegraphed huge conal AoE; inflicts deep freeze'
   - name: 'Eyeshine'
-    potency: ?
     description: '360 degree gaze inflicting deep freeze (I think?) - look away'
 job_specifics:
   DRK:

--- a/_hoh_071_enemies/hyoga.md
+++ b/_hoh_071_enemies/hyoga.md
@@ -7,6 +7,9 @@ start_floor: 71
 end_floor: 74
 patrol: true
 agro: Sight
+hp: 54000
+attack_damage: 5067
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,9 +18,11 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Absolute Zero'
-    description: 'telegraphed huge conal AoE causing deep freeze'
+    potency: ?
+    description: 'telegraphed huge conal AoE; inflicts deep freeze'
   - name: 'Eyeshine'
-    description: '360 degree gaze causing deep freeze (I think?) - look away;'
+    potency: ?
+    description: '360 degree gaze inflicting deep freeze (I think?) - look away'
 job_specifics:
   DRK:
     difficulty: Medium

--- a/_hoh_071_enemies/hyozan.md
+++ b/_hoh_071_enemies/hyozan.md
@@ -7,6 +7,9 @@ start_floor: 74
 end_floor: 76
 aptrol: true
 agro: Sight
+hp: 52000
+attack_damage: 4830
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,6 +18,7 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Ice Guillotine'
+    potency: ?
     description: 'telegraphed conal AoE'
 job_specifics:
   DRK:

--- a/_hoh_071_enemies/hyozan.md
+++ b/_hoh_071_enemies/hyozan.md
@@ -18,7 +18,6 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Ice Guillotine'
-    potency: ?
     description: 'telegraphed conal AoE'
 job_specifics:
   DRK:

--- a/_hoh_071_enemies/ichijama.md
+++ b/_hoh_071_enemies/ichijama.md
@@ -6,6 +6,9 @@ image: ichijama.png
 start_floor: 71
 end_floor: 73
 agro: Proximity
+hp: 50000
+attack_damage: 4421
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,8 +17,11 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Scream
-    description: 'telegraphed large pointblank AoE causing terror'
+    potency: ?
+    description: 'huge telegraphed pointblank AoE; inflicts terror; can be
+    interrupted'
   - name: Accursed Pox
+    potency: ?
     description: 'telegraphed circle AoE; used immediately after Scream; also
     used out of combat'
 job_specifics:

--- a/_hoh_071_enemies/ichijama.md
+++ b/_hoh_071_enemies/ichijama.md
@@ -17,11 +17,9 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Scream
-    potency: ?
     description: 'huge telegraphed pointblank AoE; inflicts terror; can be
     interrupted'
   - name: Accursed Pox
-    potency: ?
     description: 'telegraphed circle AoE; used immediately after Scream; also
     used out of combat'
 job_specifics:

--- a/_hoh_071_enemies/jujishi.md
+++ b/_hoh_071_enemies/jujishi.md
@@ -17,13 +17,10 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Freefall'
-    potency: ?
     description: 'telegraphed circle AoE'
   - name: 'Golden Talons'
-    potency: ?
     description: 'instant'
   - name: 'Winds of Winter'
-    potency: ?
     description: 'telegraphed huge pointblank AoE; can be LoSed'
 notes:
   - note: 'Rotation:'

--- a/_hoh_071_enemies/jujishi.md
+++ b/_hoh_071_enemies/jujishi.md
@@ -6,6 +6,9 @@ image: jujishi.png
 start_floor: 76
 end_floor: 79
 agro: Proximity
+hp: 54000
+attack_damage: 4547
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,11 +17,14 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Freefall'
+    potency: ?
     description: 'telegraphed circle AoE'
   - name: 'Golden Talons'
-    description: 'tankbuster'
+    potency: ?
+    description: 'instant'
   - name: 'Winds of Winter'
-    description: 'telegraphed huge pointblank AoE; can be LoS''d;'
+    potency: ?
+    description: 'telegraphed huge pointblank AoE; can be LoSed'
 notes:
   - note: 'Rotation:'
     subnotes:

--- a/_hoh_071_enemies/mammoth.md
+++ b/_hoh_071_enemies/mammoth.md
@@ -16,13 +16,12 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Wooly Inspiration'
+    potency: n/a
     description: 'telegraphed narrow but long conal AoE draw-in'
   - name: '?'
-    potency: ?
     description: 'untelegraphed conal AoE; used instantly after draw-in, but is
     a wider cone than the draw-in - get behind!'
   - name: 'Prehistoric Trumpet'
-    potency: ?
     description: 'huge untelegraphed pointblank AoE; only used out of combat'
 notes:
   - 'Be careful near mammoths when you''ve used a Pomander of Concealment, as

--- a/_hoh_071_enemies/mammoth.md
+++ b/_hoh_071_enemies/mammoth.md
@@ -5,6 +5,9 @@ image: mammoth.png
 start_floor: 74
 end_floor: 77
 agro: Sight
+hp: 51000
+attack_damage: 4256
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,10 +18,12 @@ abilities:
   - name: 'Wooly Inspiration'
     description: 'telegraphed narrow but long conal AoE draw-in'
   - name: '?'
-    description: 'non-telegraphed conal AoE; used instantly after draw-in, but
-    is a wider cone than the draw-in - get behind!'
+    potency: ?
+    description: 'untelegraphed conal AoE; used instantly after draw-in, but is
+    a wider cone than the draw-in - get behind!'
   - name: 'Prehistoric Trumpet'
-    description: 'huge non-telegraphed pointblank AoE; used out of combat only'
+    potency: ?
+    description: 'huge untelegraphed pointblank AoE; only used out of combat'
 notes:
   - 'Be careful near mammoths when you''ve used a Pomander of Concealment, as
   Prehistoric Trumpet will break the effect'

--- a/_hoh_071_enemies/mimic.md
+++ b/_hoh_071_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Malice
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_hoh_071_enemies/mimic.md
+++ b/_hoh_071_enemies/mimic.md
@@ -6,6 +6,9 @@ image: ../mimic_gold.png
 start_floor: 71
 end_floor: 79
 agro: Proximity
+hp: 54000
+attack_damage: 6554
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Malice
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_hoh_071_enemies/noyagi.md
+++ b/_hoh_071_enemies/noyagi.md
@@ -17,7 +17,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Hoofkick
-    potency: ?
     description: 'instant knockback used on anyone standing behind it'
 job_specifics:
   DRK:

--- a/_hoh_071_enemies/noyagi.md
+++ b/_hoh_071_enemies/noyagi.md
@@ -6,6 +6,9 @@ image: noyagi.png
 start_floor: 71
 end_floor: 75
 agro: Sight
+hp: 48590
+attack_damage: 4328
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,8 +17,8 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Hoofkick
-    description: 'Non-telegraphed instant knockback used on anyone standing
-    behind it'
+    potency: ?
+    description: 'instant knockback used on anyone standing behind it'
 job_specifics:
   DRK:
     difficulty: Easy

--- a/_hoh_071_enemies/okami.md
+++ b/_hoh_071_enemies/okami.md
@@ -6,6 +6,9 @@ image: okami.png
 start_floor: 72
 end_floor: 74
 agro: Sight
+hp: 49000
+attack_damage: 4007
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,8 +17,9 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Sanguine Bite
-    description: 'instant attack that drains HP and applies a strong frostbite
-    (DoT)'
+    potency: 100
+    description: 'instant; inflicts frostbite (DoT potency 50, 12s); absorbs
+    ~90% of damage dealt'
 job_specifics:
   DRK:
     difficulty: Easy

--- a/_hoh_071_enemies/shikubi.md
+++ b/_hoh_071_enemies/shikubi.md
@@ -6,6 +6,9 @@ image: shikubi.png
 start_floor: 71
 end_floor: 72
 agro: Sight
+hp: 48590
+attack_damage: 4323
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -14,6 +17,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Hypothermal Conbustion
+    potency: ?
     description: 'telegraphed pointblank AoE'
 job_specifics:
   DRK:

--- a/_hoh_071_enemies/shikubi.md
+++ b/_hoh_071_enemies/shikubi.md
@@ -17,7 +17,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Hypothermal Conbustion
-    potency: ?
     description: 'telegraphed pointblank AoE'
 job_specifics:
   DRK:

--- a/_hoh_071_enemies/shiro_jishi.md
+++ b/_hoh_071_enemies/shiro_jishi.md
@@ -21,7 +21,6 @@ abilities:
     potency: 130
     description: 'instant'
   - name: Cry
-    potency: ?
     description: 'large telegraphed pointblank AoE'
 job_specifics:
   DRK:

--- a/_hoh_071_enemies/shiro_jishi.md
+++ b/_hoh_071_enemies/shiro_jishi.md
@@ -7,6 +7,9 @@ start_floor: 76
 end_floor: 79
 patrol: true
 agro: Sight
+hp: 51000
+attack_damage: 4356
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,9 +18,11 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Pounce
-    description: tankbuster
+    potency: 130
+    description: 'instant'
   - name: Cry
-    description: telegraphed pointblank AoE
+    potency: ?
+    description: 'large telegraphed pointblank AoE'
 job_specifics:
   DRK:
     difficulty: Easy

--- a/_hoh_071_enemies/tofu.md
+++ b/_hoh_071_enemies/tofu.md
@@ -6,6 +6,9 @@ image: tofu.png
 start_floor: 75
 end_floor: 78
 agro: Sight
+hp: 49000
+attack_damage: 4084
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,9 +17,10 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Blizzard
-    description: 'Used frequently in addition to melee auto-attacks'
+    potency: 100
+    description: 'used frequently in addition to melee auto-attacks'
   - name: Golden Tongue
-    description: 'Grants damage up'
+    description: 'grants magic damage up (50%, 30s) to self'
 notes:
   - 'Does not make an effort to come into melee range unless Golden Tongue is
   interrupted'

--- a/_hoh_071_enemies/tofu.md
+++ b/_hoh_071_enemies/tofu.md
@@ -20,6 +20,7 @@ abilities:
     potency: 100
     description: 'used frequently in addition to melee auto-attacks'
   - name: Golden Tongue
+    potency: n/a
     description: 'grants magic damage up (50%, 30s) to self'
 notes:
   - 'Does not make an effort to come into melee range unless Golden Tongue is

--- a/_hoh_071_enemies/yak.md
+++ b/_hoh_071_enemies/yak.md
@@ -6,6 +6,9 @@ image: yak.png
 start_floor: 77
 end_floor: 79
 agro: Sight
+hp: 54000
+attack_damage: 5070
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,9 +17,10 @@ vulnerabilities:
   stun: false
 abilities:
   - name: '?'
-    description: 'draw-in that applies heavy; used exactly 30 second after
+    description: 'draw-in that inflicts heavy; used exactly 30 seconds after
     pull; knockback immunity works'
   - name: 'Horrisonous Blast'
+    potency: ?
     description: 'large pointblank AoE; used immediately after draw-in; can
     be interrupted'
 job_specifics:

--- a/_hoh_071_enemies/yak.md
+++ b/_hoh_071_enemies/yak.md
@@ -17,10 +17,10 @@ vulnerabilities:
   stun: false
 abilities:
   - name: '?'
+    potency: n/a
     description: 'draw-in that inflicts heavy; used exactly 30 seconds after
     pull; knockback immunity works'
   - name: 'Horrisonous Blast'
-    potency: ?
     description: 'large pointblank AoE; used immediately after draw-in; can
     be interrupted'
 job_specifics:

--- a/_hoh_071_enemies/yuki_otoko.md
+++ b/_hoh_071_enemies/yuki_otoko.md
@@ -6,6 +6,9 @@ image: yuki_otoko.png
 start_floor: 77
 end_floor: 79
 agro: Sight
+hp: 54000
+attack_damage: 4728
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: true
@@ -14,10 +17,12 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Frozen Mist'
-    description: 'telegraphed conal AoE causing deep freeze'
+    potency: ?
+    description: 'telegraphed conal AoE; inflicts deep freeze'
   - name: 'Northerlies'
-    description: 'telegraphed huge pointblank AoE; used after second Frozen
-    Mist; can be interrupted or LoS''d'
+    potency: ?
+    description: 'telegraphed huge pointblank AoE; used 21 seconds after pull,
+    then at 50-second intervals; can be interrupted or LoSed'
 job_specifics:
   DRK:
     difficulty: Easy

--- a/_hoh_071_enemies/yuki_otoko.md
+++ b/_hoh_071_enemies/yuki_otoko.md
@@ -17,10 +17,8 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Frozen Mist'
-    potency: ?
     description: 'telegraphed conal AoE; inflicts deep freeze'
   - name: 'Northerlies'
-    potency: ?
     description: 'telegraphed huge pointblank AoE; used 21 seconds after pull,
     then at 50-second intervals; can be interrupted or LoSed'
 job_specifics:

--- a/_hoh_071_enemies/yuki_tokage.md
+++ b/_hoh_071_enemies/yuki_tokage.md
@@ -17,10 +17,8 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Chilling Cyclone'
-    potency: ?
     description: 'telegraphed conal AoE; possibly inflicts deep freeze'
   - name: 'Ice Dispenser'
-    potency: ?
     description: 'telegraphed circle AoE; also used out of combat'
 job_specifics:
   DRK:

--- a/_hoh_071_enemies/yuki_tokage.md
+++ b/_hoh_071_enemies/yuki_tokage.md
@@ -6,6 +6,9 @@ image: yuki_tokage.png
 start_floor: 73
 end_floor: 77
 agro: Sight
+hp: 49000
+attack_damage: 4452
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,8 +17,10 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Chilling Cyclone'
-    description: 'telegraphed conal AoE'
+    potency: ?
+    description: 'telegraphed conal AoE; possibly inflicts deep freeze'
   - name: 'Ice Dispenser'
+    potency: ?
     description: 'telegraphed circle AoE; also used out of combat'
 job_specifics:
   DRK:

--- a/_hoh_081_enemies/araragi.md
+++ b/_hoh_081_enemies/araragi.md
@@ -1,11 +1,14 @@
 ---
 name: Heavenly Araragi
 nickname: Araragi
-family: Goobue
+family: Goobbue
 image: araragi.png
 start_floor: 86
 end_floor: 89
 agro: Sight
+hp: 59000
+attack_damage: 3819
+attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
@@ -13,30 +16,34 @@ vulnerabilities:
   slow: unknown
   stun: false
 abilities:
-  - name: 'Goobue''s Grief'
-    description: 'applies a stacking poison; used frequently'
+  - name: 'Goobbue''s Grief'
+    potency: 50
+    description: 'untelegraphed pointblank(?) AoE; inflicts stacking poison
+    (DoT potency 15 per stack, 30s); used frequently'
   - name: 'Moldy Phlegm'
+    potency: ?
     description: 'telegraphed circle AoE'
   - name: '?'
-    description: 'telegraphed conal AoE draw-in'
+    description: 'instant conal AoE draw-in'
   - name: 'Moldy Sneeze'
+    potency: ?
     description: 'telegraphed conal AoE; used immediately after draw-in; actual
     AoE may be wider than the telegraph - get behind!'
 notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Goobue''s Grief'
+      - 'Goobbue''s Grief'
       - 'Moldy Phlegm'
-      - 'Goobue''s Grief'
+      - 'Goobbue''s Grief'
       - 'draw-in + Moldy Sneeze'
-      - 'Goobue''s Grief'
-      - 'Time for roughly 3 auto-attacks before it restarts (another Goobue''s
+      - 'Goobbue''s Grief'
+      - 'Time for roughly 3 auto-attacks before it restarts (another Goobbue''s
       Grief)'
 job_specifics:
   MCH:
-    difficulty: 'Easy if you can LoS Goobue''s Grief well'
+    difficulty: 'Easy if you can LoS Goobbue''s Grief well'
     notes:
       - 'Steel and/or burst recommended if you can''t LoS well'
   PLD:
-    difficulty: 'Easy if you can LoS Goobue''s Grief well'
+    difficulty: 'Easy if you can LoS Goobbue''s Grief well'
 ---

--- a/_hoh_081_enemies/araragi.md
+++ b/_hoh_081_enemies/araragi.md
@@ -21,12 +21,11 @@ abilities:
     description: 'untelegraphed pointblank(?) AoE; inflicts stacking poison
     (DoT potency 15 per stack, 30s); used frequently'
   - name: 'Moldy Phlegm'
-    potency: ?
     description: 'telegraphed circle AoE'
   - name: '?'
+    potency: n/a
     description: 'instant conal AoE draw-in'
   - name: 'Moldy Sneeze'
-    potency: ?
     description: 'telegraphed conal AoE; used immediately after draw-in; actual
     AoE may be wider than the telegraph - get behind!'
 notes:

--- a/_hoh_081_enemies/enko.md
+++ b/_hoh_081_enemies/enko.md
@@ -5,6 +5,9 @@ image: enko.png
 start_floor: 86
 end_floor: 89
 agro: Sight
+hp: 58000
+attack_damage: 5205
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -12,10 +15,15 @@ vulnerabilities:
   slow: true
   stun: true
 abilities:
-  - name: 'Straight Punch'
-    description: 'tankbuster'
-  - name: 'Plain Pound'
+  - name: Straight Punch
+    potency: 130
+    description: 'instant'
+  - name: Plain Pound
+    potency: ?
     description: 'telegraphed circle AoE'
+  - name: Flex
+    description: 'enrage; grants physical damage up (200%, 1m) to self; used
+    about 1 minute after pull'
 job_specifics:
   DRK:
     difficulty: Medium

--- a/_hoh_081_enemies/enko.md
+++ b/_hoh_081_enemies/enko.md
@@ -19,9 +19,9 @@ abilities:
     potency: 130
     description: 'instant'
   - name: Plain Pound
-    potency: ?
     description: 'telegraphed circle AoE'
   - name: Flex
+    potency: n/a
     description: 'enrage; grants physical damage up (200%, 1m) to self; used
     about 1 minute after pull'
 job_specifics:

--- a/_hoh_081_enemies/garula.md
+++ b/_hoh_081_enemies/garula.md
@@ -7,6 +7,9 @@ start_floor: 81
 end_floor: 84
 patrol: true
 agro: Sight
+hp: 62921
+attack_damage: 5782
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,14 +18,18 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Rush'
-    description: 'gap-closer/tankbuster; used immediately on pull'
+    potency: 130
+    description: 'instant gap closer; used immediately on pull'
   - name: 'Heave'
+    potency: ?
     description: 'telegraphed conal AoE'
   - name: 'Disorienting Groan'
-    description: 'telegraphed large pointblank AoE; can be LoS''d'
+    potency: ?
+    description: 'telegraphed large pointblank AoE; can be LoSed'
   - name: 'Earthquake'
-    description: 'stands in place and does 6 stomps, each a non-telegraphed
-    huge pointblank AoE; can be LoS''d'
+    potency: ?
+    description: 'stands in place and does 6 stomps, each an untelegraphed
+    huge pointblank AoE; can be LoSed'
 notes:
   - 'You can duck behind a corner as it uses Rush to steer it into the wall.
   You''ll still take damage, but it can give you a chance to heal before it''s

--- a/_hoh_081_enemies/garula.md
+++ b/_hoh_081_enemies/garula.md
@@ -21,13 +21,10 @@ abilities:
     potency: 130
     description: 'instant gap closer; used immediately on pull'
   - name: 'Heave'
-    potency: ?
     description: 'telegraphed conal AoE'
   - name: 'Disorienting Groan'
-    potency: ?
     description: 'telegraphed large pointblank AoE; can be LoSed'
   - name: 'Earthquake'
-    potency: ?
     description: 'stands in place and does 6 stomps, each an untelegraphed
     huge pointblank AoE; can be LoSed'
 notes:

--- a/_hoh_081_enemies/gozu.md
+++ b/_hoh_081_enemies/gozu.md
@@ -5,6 +5,9 @@ image: gozu.png
 start_floor: 81
 end_floor: 85
 agro: Sight
+hp: 60682
+attack_damage: 5560
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,12 +16,13 @@ vulnerabilities:
   stun: false
 abilities:
   - name: '11-tonze Swipe'
-    description: 'non-telegraphed conal AoE. Can be LoS''d'
+    potency: 750
+    description: 'untelegraphed conal AoE; can be LoSed'
   - name: 'Hex'
     description: '360 degree gaze attack that turns you into a pig - look
     away!'
   - name: 'Devour'
-    description: 'Instant death; only used if you''ve been turned into a pig'
+    description: 'instant death; only used if you''ve been turned into a pig'
 job_specifics:
   DRK:
     difficulty: Easy

--- a/_hoh_081_enemies/gozu.md
+++ b/_hoh_081_enemies/gozu.md
@@ -19,9 +19,11 @@ abilities:
     potency: 750
     description: 'untelegraphed conal AoE; can be LoSed'
   - name: 'Hex'
+    potency: n/a
     description: '360 degree gaze attack that turns you into a pig - look
     away!'
   - name: 'Devour'
+    potency: n/a
     description: 'instant death; only used if you''ve been turned into a pig'
 job_specifics:
   DRK:

--- a/_hoh_081_enemies/hitotsume.md
+++ b/_hoh_081_enemies/hitotsume.md
@@ -6,6 +6,9 @@ image: hitotsume.png
 start_floor: 85
 end_floor: 88
 agro: Sight
+hp: 60682
+attack_damage: 5560
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,9 +17,11 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Glower'
-    description: 'non-telegraphed wide line AoE - get to the side or behind'
+    potency: ?
+    description: 'untelegraphed wide line AoE - get to the side or behind'
   - name: '100-tonze Swing'
-    description: 'non-telegraphed pointblank AoE - get away'
+    potency: ?
+    description: 'untelegraphed pointblank AoE inflicting knockback - get away'
 job_specifics:
   DRK:
     difficulty: Easy

--- a/_hoh_081_enemies/hitotsume.md
+++ b/_hoh_081_enemies/hitotsume.md
@@ -17,10 +17,8 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Glower'
-    potency: ?
     description: 'untelegraphed wide line AoE - get to the side or behind'
   - name: '100-tonze Swing'
-    potency: ?
     description: 'untelegraphed pointblank AoE inflicting knockback - get away'
 job_specifics:
   DRK:

--- a/_hoh_081_enemies/koki.md
+++ b/_hoh_081_enemies/koki.md
@@ -5,6 +5,9 @@ image: koki.png
 start_floor: 86
 end_floor: 89
 agro: Proximity
+hp: 58443
+attack_damage: 5257
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -12,13 +15,17 @@ vulnerabilities:
   slow: true
   stun: unknown
 abilities:
-  - name: 'Spiral Spin'
+  - name: Spiral Spin
+    potency: ?
     description: 'telegraphed donut AoE'
-  - name: 'Vile Utterance'
-    description: 'telegraphed conal AoE'
-  - name: '?'
-    description: 'non-telegraphed huge pointblank AoE that applies a stacking
-    vulnerability up; can be LoS''d'
+  - name: Vile Utterance
+    potency: ?
+    description: 'telegraphed narrow but long conal AoE'
+  - name: Blood Moon
+    potency: 50
+    description: 'untelegraphed huge pointblank AoE; inflicts stacking
+    vulnerability up (5%? per stack, 30s). Can be LoSed, and fully shielding
+    the damage also blocks the vulnerability up'
 notes:
   - 'If you let it do one auto-attack after Vile Utterance and then duck behind
   a corner, you should avoid the vulnerability up'

--- a/_hoh_081_enemies/koki.md
+++ b/_hoh_081_enemies/koki.md
@@ -16,10 +16,8 @@ vulnerabilities:
   stun: unknown
 abilities:
   - name: Spiral Spin
-    potency: ?
     description: 'telegraphed donut AoE'
   - name: Vile Utterance
-    potency: ?
     description: 'telegraphed narrow but long conal AoE'
   - name: Blood Moon
     potency: 50

--- a/_hoh_081_enemies/matanga.md
+++ b/_hoh_081_enemies/matanga.md
@@ -5,6 +5,9 @@ image: matanga.png
 start_floor: 81
 end_floor: 85
 agro: Sight
+hp: 60682
+attack_damage: 5560
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,10 +16,13 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Buffet'
-    description: 'gap-closer/tankbuster; used immediately on pull'
+    potency: 150
+    description: 'instant gap closer; used immediately on pull'
   - name: 'Spin'
+    potency: ?
     description: 'telegraphed conal AoE'
   - name: 'Hurl'
+    potency: ?
     description: 'telegraphed circle AoE'
 notes:
   - 'You can duck behind a corner as it uses Buffet to steer it into the wall.

--- a/_hoh_081_enemies/matanga.md
+++ b/_hoh_081_enemies/matanga.md
@@ -19,10 +19,8 @@ abilities:
     potency: 150
     description: 'instant gap closer; used immediately on pull'
   - name: 'Spin'
-    potency: ?
     description: 'telegraphed conal AoE'
   - name: 'Hurl'
-    potency: ?
     description: 'telegraphed circle AoE'
 notes:
   - 'You can duck behind a corner as it uses Buffet to steer it into the wall.

--- a/_hoh_081_enemies/mimic.md
+++ b/_hoh_081_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Malice
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_hoh_081_enemies/mimic.md
+++ b/_hoh_081_enemies/mimic.md
@@ -6,6 +6,9 @@ image: ../mimic_gold.png
 start_floor: 81
 end_floor: 89
 agro: Proximity
+hp: 58000
+attack_damage: 7557
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Malice
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_hoh_081_enemies/mukai_inu.md
+++ b/_hoh_081_enemies/mukai_inu.md
@@ -5,6 +5,9 @@ image: mukai_inu.png
 start_floor: 81
 end_floor: 84
 agro: Proximity
+hp: 64000
+attack_damage: 6052
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,15 +16,22 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'The Dragon''s Voice'
+    potency: ?
     description: 'untelegraphed donut AoE - get IN. Can be interrupted'
   - name: 'The Ram''s Voice'
+    potency: ?
     description: 'untelegraphed pointblank AoE - get OUT. Can be interrupted'
+  - name: 'The Dragon''s Breath'
+    potency: ?
+    description: 'telegraphed conal AoE'
   - name: 'The Lion''s Breath'
+    potency: ?
     description: 'telegraphed conal AoE'
   - name: 'The Ram''s Breath'
+    potency: ?
     description: 'telegraphed conal AoE'
 notes:
-  - 'These mostly just spam abilities, doing very little autoattack damage'
+  - 'These mostly just spam abilities, doing very little auto-attack damage'
   - 'Try to stand behind it during Dragon''s Voice and Breath attacks to delay
   its next auto-attack'
 job_specifics:
@@ -33,7 +43,7 @@ job_specifics:
     difficulty: Easy
     notes:
       - 'Try to always stay at a medium range, so it''s easy to move in or out
-        when necessary. A bit of range will help to avoid some autoattacks too'
+        when necessary. A bit of range will help to avoid some auto-attacks too'
       - 'Can interrupt a Voice if you need to, but save for emergencies
         (avoiding another patrol, etc.)'
   PLD:

--- a/_hoh_081_enemies/mukai_inu.md
+++ b/_hoh_081_enemies/mukai_inu.md
@@ -16,19 +16,14 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'The Dragon''s Voice'
-    potency: ?
     description: 'untelegraphed donut AoE - get IN. Can be interrupted'
   - name: 'The Ram''s Voice'
-    potency: ?
     description: 'untelegraphed pointblank AoE - get OUT. Can be interrupted'
   - name: 'The Dragon''s Breath'
-    potency: ?
     description: 'telegraphed conal AoE'
   - name: 'The Lion''s Breath'
-    potency: ?
     description: 'telegraphed conal AoE'
   - name: 'The Ram''s Breath'
-    potency: ?
     description: 'telegraphed conal AoE'
 notes:
   - 'These mostly just spam abilities, doing very little auto-attack damage'

--- a/_hoh_081_enemies/rakshasa.md
+++ b/_hoh_081_enemies/rakshasa.md
@@ -19,7 +19,8 @@ vulnerabilities:
 abilities:
   - name: Wild Charge
     potency: 130?
-    description: 'instant gap closer'
+    description: 'instant gap closer; used immediately on pull, and again when
+    its damage down debuff (see next ability) wears off'
   - name: 'Enrage (?)'
     potency: n/a
     description: 'grants damage up (25%, 30s) to self; used immediately after

--- a/_hoh_081_enemies/rakshasa.md
+++ b/_hoh_081_enemies/rakshasa.md
@@ -7,6 +7,9 @@ start_floor: 86
 end_floor: 89
 patrol: true
 agro: Sight
+hp: 62921
+attack_damage: 5879
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,15 +17,18 @@ vulnerabilities:
   slow: unknown
   stun: false
 abilities:
-  - name: 'Wild Charge'
-    description: 'gap closer/tankbuster; used immediately on pull, and again
-    if/when its damage down debuff (see next ability) wears off'
-  - name: '?'
-    description: 'grants damage up for 30s; when damage up wears off, it is
-    replaced with damage down'
-  - name: 'Ripper Claw'
-    description: 'non-telegraphed conal AoE - get away or behind'
-  - name: 'Fireball'
+  - name: Wild Charge
+    potency: 130?
+    description: 'instant gap closer'
+  - name: 'Enrage (?)'
+    description: 'grants damage up (25%, 30s) to self; used immediately after
+    Wild Charge. When the buff expires, it changes to a physical damage down
+    debuff (60%?, 30s)'
+  - name: Ripper Claw
+    potency: ?
+    description: 'untelegraphed conal AoE - get away or behind'
+  - name: Fireball
+    potency: ?
     description: 'telegraphed circle AoE'
 job_specifics:
   DRK:

--- a/_hoh_081_enemies/rakshasa.md
+++ b/_hoh_081_enemies/rakshasa.md
@@ -21,14 +21,13 @@ abilities:
     potency: 130?
     description: 'instant gap closer'
   - name: 'Enrage (?)'
+    potency: n/a
     description: 'grants damage up (25%, 30s) to self; used immediately after
     Wild Charge. When the buff expires, it changes to a physical damage down
     debuff (60%?, 30s)'
   - name: Ripper Claw
-    potency: ?
     description: 'untelegraphed conal AoE - get away or behind'
   - name: Fireball
-    potency: ?
     description: 'telegraphed circle AoE'
 job_specifics:
   DRK:

--- a/_hoh_081_enemies/rowan.md
+++ b/_hoh_081_enemies/rowan.md
@@ -6,6 +6,9 @@ image: rowan.png
 start_floor: 81
 end_floor: 83
 agro: Sight
+hp: 60682
+attack_damage: 5560
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -13,15 +16,17 @@ vulnerabilities:
   slow: true
   stun: unknown
 abilities:
-  - name: Ripe Banana
-    description: 'used out of combat only. Grants a strong attack boost. After
-    using this, it will use Chest Thump every few seconds until the buff
-    expires'
-  - name: Chest Thump
-    description: 'huge 1.5 room instant AoE that applies stacking vulnerability
-    up. Only used out of combat during Ripe Banana'
   - name: Browbeat
-    description: 'tankbuster'
+    potency: 120?
+    description: 'instant'
+  - name: Ripe Banana
+    description: 'grants physical damage up (100%?, 15s) to self; only used out
+    of combat. After using this, it will use Chest Thump every few seconds
+    until the buff expires'
+  - name: Chest Thump
+    description: 'huge 1.5 room instant AoE that inflicts stacking physical
+    vulnerability up (10% per stack, max 5 stacks, 8s). Only used out of combat
+    during Ripe Banana'
 notes:
   - Hits VERY hard
   - DO NOT pull while it has the attack bonus

--- a/_hoh_081_enemies/rowan.md
+++ b/_hoh_081_enemies/rowan.md
@@ -20,10 +20,12 @@ abilities:
     potency: 120?
     description: 'instant'
   - name: Ripe Banana
+    potency: n/a
     description: 'grants physical damage up (100%?, 15s) to self; only used out
     of combat. After using this, it will use Chest Thump every few seconds
     until the buff expires'
   - name: Chest Thump
+    potency: n/a
     description: 'huge 1.5 room instant AoE that inflicts stacking physical
     vulnerability up (10% per stack, max 5 stacks, 8s). Only used out of combat
     during Ripe Banana'

--- a/_hoh_081_enemies/ryujin.md
+++ b/_hoh_081_enemies/ryujin.md
@@ -19,10 +19,8 @@ abilities:
     potency: 130
     description: 'instant'
   - name: 'Firewater'
-    potency: ?
     description: 'telegraphed circle AoE'
   - name: Elbow Drop'
-    potency: ?
     description: 'untelegraphed backward conal AoE; used if someone is behind'
 notes:
   - 'Elbow Drop can be baited to delay its auto-attacks; just don''t get hit by

--- a/_hoh_081_enemies/ryujin.md
+++ b/_hoh_081_enemies/ryujin.md
@@ -5,6 +5,9 @@ image: ryujin.png
 start_floor: 84
 end_floor: 87
 agro: Sight
+hp: 60682
+attack_damage: 5560
+attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
@@ -13,12 +16,14 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Straight Punch'
-    description: 'tankbuster'
+    potency: 130
+    description: 'instant'
   - name: 'Firewater'
+    potency: ?
     description: 'telegraphed circle AoE'
   - name: Elbow Drop'
-    description: 'non-telegraphed conal AoE BEHIND the enemy; used if there is
-    someone behind after Firewater'
+    potency: ?
+    description: 'untelegraphed backward conal AoE; used if someone is behind'
 notes:
   - 'Elbow Drop can be baited to delay its auto-attacks; just don''t get hit by
   it!'

--- a/_hoh_081_enemies/ryukotsu.md
+++ b/_hoh_081_enemies/ryukotsu.md
@@ -17,7 +17,6 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Rock of Ages'
-    potency: ?
     description: 'telegraphed circle AoE; also used out of combat'
 job_specifics:
   DRK:

--- a/_hoh_081_enemies/ryukotsu.md
+++ b/_hoh_081_enemies/ryukotsu.md
@@ -6,6 +6,9 @@ image: ryukotsu.png
 start_floor: 83
 end_floor: 87
 agro: Sight
+hp: 60682
+attack_damage: 5560
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -14,6 +17,7 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Rock of Ages'
+    potency: ?
     description: 'telegraphed circle AoE; also used out of combat'
 job_specifics:
   DRK:

--- a/_hoh_081_enemies/shinzei.md
+++ b/_hoh_081_enemies/shinzei.md
@@ -7,6 +7,9 @@ start_floor: 84
 end_floor: 86
 patrol: true
 agro: Sight
+hp: 62921
+attack_damage: 5782
+attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
@@ -15,12 +18,16 @@ vulnerabilities:
   stun: false
 abilities:
   - name: Body Blow
-    description: 'tankbuster; applies Concussion (DoT)'
-  - name: Atomic Breath
+    potency: 100
+    description: 'instant; inflicts concussion (DoT potency 50?, 15s)'
+  - name: Anoxic Breath
+    potency: ?
     description: 'telegraphed conal AoE'
   - name: Thunder II
+    potency: 80 + 30x3
     description: 'circle AoE on marked target hitting 3 times after the initial
-    cast; causes Electrocution (DoT); can be interrupted'
+    cast; inflicts electrocution (DoT potency 10, 30s) on each hit; can be
+    interrupted'
 job_specifics:
   DRK:
     difficulty: Medium

--- a/_hoh_081_enemies/shinzei.md
+++ b/_hoh_081_enemies/shinzei.md
@@ -21,7 +21,6 @@ abilities:
     potency: 100
     description: 'instant; inflicts concussion (DoT potency 50?, 15s)'
   - name: Anoxic Breath
-    potency: ?
     description: 'telegraphed conal AoE'
   - name: Thunder II
     potency: 80 + 30x3

--- a/_hoh_091_enemies/dodo.md
+++ b/_hoh_091_enemies/dodo.md
@@ -21,6 +21,7 @@ abilities:
     description: 'instant; inflicts sleep (10s); used when HP drops below 60%.
     Diminishing returns do NOT apply to this sleep (it is always 10s)'
   - name: Strut
+    potency: n/a
     description: 'grants haste (25s) to self; used immediately after Fowl
     Stench'
 notes:

--- a/_hoh_091_enemies/dodo.md
+++ b/_hoh_091_enemies/dodo.md
@@ -3,14 +3,26 @@ name: Heavenly Dodo
 start_floor: 99
 end_floor: 99
 agro: Sight
+hp: 73669
+attack_damage: 6684
+attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
   sleep: unknown
   slow: true
   stun: true
-  resolution: true
-gallery_only: true
+abilities:
+  - name: Peck
+    potency: 130
+    description: 'instant'
+  - name: Fowl Stench
+    potency: 130
+    description: 'instant; inflicts sleep (10s); used when HP drops below 60%.
+    Diminishing returns do NOT apply to this sleep (it is always 10s)'
+  - name: Strut
+    description: 'grants haste (25s) to self; used immediately after Fowl
+    Stench'
 notes:
   - 'Rare spawn'
 ---

--- a/_hoh_091_enemies/gozu.md
+++ b/_hoh_091_enemies/gozu.md
@@ -24,11 +24,9 @@ abilities:
     potency: 100
     description: 'instant'
   - name: '32-tonze Swipe'
-    potency: ?
     description: 'untelegraphed long conal AoE - get to side or behind; can
     also be LoSed'
   - name: '128-tonze Swing'
-    potency: ?
     description: 'untelegraphed pointblank AoE - get away'
 job_specifics:
   DRK:

--- a/_hoh_091_enemies/gozu.md
+++ b/_hoh_091_enemies/gozu.md
@@ -7,6 +7,9 @@ start_floor: 91
 end_floor: 94
 patrol: true
 agro: Sight
+hp: 72326
+attack_damage: 6097
+attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
@@ -15,14 +18,18 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Zoom In'
-    description: 'gap closer/tankbuster; used immediately on pull'
+    potency: 150
+    description: 'instant gap closer; used immediately on pull'
   - name: '16-tonze Swipe'
-    description: 'instant cleave'
-  - name: '31-tonze Swipe'
-    description: 'non-telegraphed long conal AoE - get to side or behind; can
-    also be LoS''d'
+    potency: 100
+    description: 'instant'
+  - name: '32-tonze Swipe'
+    potency: ?
+    description: 'untelegraphed long conal AoE - get to side or behind; can
+    also be LoSed'
   - name: '128-tonze Swing'
-    description: 'non-telegraphed pointblank AoE - get away'
+    potency: ?
+    description: 'untelegraphed pointblank AoE - get away'
 job_specifics:
   DRK:
     difficulty: Medium

--- a/_hoh_091_enemies/jaki.md
+++ b/_hoh_091_enemies/jaki.md
@@ -20,6 +20,7 @@ abilities:
     potency: 85
     description: 'instant'
   - name: 'Charybdis'
+    potency: n/a
     description: 'circle AoE on marked player; drops you to 1 HP; can be
     interrupted or LoSed'
 job_specifics:

--- a/_hoh_091_enemies/jaki.md
+++ b/_hoh_091_enemies/jaki.md
@@ -6,6 +6,9 @@ image: jaki.png
 start_floor: 93
 end_floor: 95
 agro: Sight
+hp: 72326
+attack_damage: 6040
+attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: true
@@ -13,11 +16,12 @@ vulnerabilities:
   slow: true
   stun: true
 abilities:
+  - name: 'Dark Dome'
+    potency: 85
+    description: 'instant'
   - name: 'Charybdis'
     description: 'circle AoE on marked player; drops you to 1 HP; can be
-    interrupted or LoS''d'
-  - name: 'Dark Dome'
-    description: 'tankbuster'
+    interrupted or LoSed'
 job_specifics:
   DRK:
     difficulty: 'Medium'

--- a/_hoh_091_enemies/jinba.md
+++ b/_hoh_091_enemies/jinba.md
@@ -20,9 +20,9 @@ abilities:
     potency: 90
     description: 'instant'
   - name: 'Allagan Fear'
+    potency: n/a
     description: '360 degree gaze - look away'
   - name: 'Allagan Meteor'
-    potency: ?
     description: 'huge circle AoE; can LoS (from centre of circle)'
 job_specifics:
   MCH:

--- a/_hoh_091_enemies/jinba.md
+++ b/_hoh_091_enemies/jinba.md
@@ -6,6 +6,9 @@ image: jinba.png
 start_floor: 94
 end_floor: 96
 agro: Sight
+hp: 70086
+attack_damage: 6322
+attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
@@ -14,10 +17,12 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Hard Thrust'
-    description: 'tankbuster'
+    potency: 90
+    description: 'instant'
   - name: 'Allagan Fear'
     description: '360 degree gaze - look away'
   - name: 'Allagan Meteor'
+    potency: ?
     description: 'huge circle AoE; can LoS (from centre of circle)'
 job_specifics:
   MCH:

--- a/_hoh_091_enemies/kubinashi.md
+++ b/_hoh_091_enemies/kubinashi.md
@@ -7,6 +7,8 @@ start_floor: 94
 end_floor: 96
 patrol: true
 agro: Sight
+hp: 72326
+attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
@@ -14,13 +16,15 @@ vulnerabilities:
   slow: true
   stun: false
 abilities:
-  - name: 'Drainstrikes'
-    description: 'grants drainstrikes - attacks drain HP from target, healing
-    self'
   - name: 'Iron Justice'
+    potency: ?
     description: 'Cleave'
+  - name: 'Drainstrikes'
+    description: 'grants drainstrikes (30s) - attacks drain HP from target,
+    healing self'
   - name: 'Cloudcover'
-    description: 'Telegraphed circle AoE; can be interrupted'
+    potency: ?
+    description: 'telegraphed circle AoE; can be interrupted'
 notes:
   - 'Each time it grows, it gains a stacking damage up buff'
   - note: 'Pattern:'

--- a/_hoh_091_enemies/kubinashi.md
+++ b/_hoh_091_enemies/kubinashi.md
@@ -17,13 +17,12 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Iron Justice'
-    potency: ?
     description: 'Cleave'
   - name: 'Drainstrikes'
+    potency: n/a
     description: 'grants drainstrikes (30s) - attacks drain HP from target,
     healing self'
   - name: 'Cloudcover'
-    potency: ?
     description: 'telegraphed circle AoE; can be interrupted'
 notes:
   - 'Each time it grows, it gains a stacking damage up buff'

--- a/_hoh_091_enemies/kuro_kishi.md
+++ b/_hoh_091_enemies/kuro_kishi.md
@@ -20,7 +20,6 @@ abilities:
     potency: 100
     description: 'instant'
   - name: 'Void Trap'
-    potency: ?
     description: 'telegraphed circle AoE'
 job_specifics:
   DRK:

--- a/_hoh_091_enemies/kuro_kishi.md
+++ b/_hoh_091_enemies/kuro_kishi.md
@@ -6,6 +6,9 @@ image: kuro_kishi.png
 start_floor: 96
 end_floor: 99
 agro: Proximity
+hp: 70086
+attack_damage: 6658
+attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
@@ -13,10 +16,12 @@ vulnerabilities:
   slow: unknown
   stun: true
 abilities:
-  - name: 'Void Trap'
-    description: 'telegraphed circle AoE'
   - name: 'Void Slash'
-    description: 'tankbuster'
+    potency: 100
+    description: 'instant'
+  - name: 'Void Trap'
+    potency: ?
+    description: 'telegraphed circle AoE'
 job_specifics:
   DRK:
     difficulty: 'Easy'

--- a/_hoh_091_enemies/kyozo.md
+++ b/_hoh_091_enemies/kyozo.md
@@ -17,9 +17,9 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Gust'
-    potency: ?
     description: 'telegraphed circle AoE; also used out of combat'
   - name: 'Filoplumage'
+    potency: n/a
     description: 'grants vulnerability down (50%, 15s) to self and other nearby
     enemies; can be interrupted'
 job_specifics:

--- a/_hoh_091_enemies/kyozo.md
+++ b/_hoh_091_enemies/kyozo.md
@@ -4,8 +4,11 @@ nickname: Kyozo
 family: Mirror Knight
 image: kyozo.png
 start_floor: 95
-end_floor: 97
+end_floor: 98
 agro: Sight
+hp: 68743
+attack_damage: 6194
+attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
@@ -14,10 +17,11 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Gust'
+    potency: ?
     description: 'telegraphed circle AoE; also used out of combat'
   - name: 'Filoplumage'
-    description: 'grants vulnerability down to self and other nearby enemies;
-    can be interrupted'
+    description: 'grants vulnerability down (50%, 15s) to self and other nearby
+    enemies; can be interrupted'
 job_specifics:
   DRK:
     difficulty: 'Easy'

--- a/_hoh_091_enemies/mifune.md
+++ b/_hoh_091_enemies/mifune.md
@@ -5,6 +5,9 @@ image: mifune.png
 start_floor: 91
 end_floor: 99
 agro: Proximity
+hp: 73669
+attack_damage: 6813
+attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
@@ -13,7 +16,8 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Valfodr'
-    description: 'telegraphed charge AoE; can be LoS''d'
+    potency: 300
+    description: 'telegraphed charge AoE; can be LoSed'
 job_specifics:
   DRK:
     difficulty: 'Medium'

--- a/_hoh_091_enemies/mimic.md
+++ b/_hoh_091_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Malice
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_hoh_091_enemies/mimic.md
+++ b/_hoh_091_enemies/mimic.md
@@ -6,6 +6,9 @@ image: ../mimic_gold.png
 start_floor: 91
 end_floor: 99
 agro: Proximity
+hp: 64000
+attack_damage: 9038
+attack_type: Physical
 vulnerabilities:
   bind: false
   heavy: false
@@ -15,8 +18,9 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Malice
-    description: 'inflicts pox; can be interrupted'
+    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
+    potency: 300
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_hoh_091_enemies/nuppeppo_mnk.md
+++ b/_hoh_091_enemies/nuppeppo_mnk.md
@@ -6,6 +6,9 @@ image: nuppeppo_mnk.png
 start_floor: 91
 end_floor: 94
 agro: Sight
+hp: 69191
+attack_damage: 3023
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
@@ -14,13 +17,15 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Footwork'
-    description: 'grants haste'
+    description: 'grants haste (25s) to self'
   - name: 'Featherfoot'
-    description: 'grants evasion up'
+    description: 'grants evasion up (5s) to self; used immediately after
+    Footwork'
   - name: 'Gutripper'
-    description: 'applies concussion (DoT)'
+    description: 'inflicts concussion (DoT potency 100, 15s)'
   - name: 'Triple Threat'
-    description: 'tankbuster; 3 hits, used 3 times in a row (9 hits total)'
+    potency: 40 (x3)
+    description: 'instant 3-hit attack; used 3 times in a row (9 hits total)'
 job_specifics:
   DRK:
     difficulty: Medium

--- a/_hoh_091_enemies/nuppeppo_mnk.md
+++ b/_hoh_091_enemies/nuppeppo_mnk.md
@@ -17,11 +17,14 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Footwork'
+    potency: n/a
     description: 'grants haste (25s) to self'
   - name: 'Featherfoot'
+    potency: n/a
     description: 'grants evasion up (5s) to self; used immediately after
     Footwork'
   - name: 'Gutripper'
+    potency: n/a
     description: 'inflicts concussion (DoT potency 100, 15s)'
   - name: 'Triple Threat'
     potency: 40 (x3)

--- a/_hoh_091_enemies/nuppeppo_war.md
+++ b/_hoh_091_enemies/nuppeppo_war.md
@@ -16,10 +16,10 @@ vulnerabilities:
   slow: true
   stun: true
 abilities:
-  - name: 'Poleaxe (?)'
+  - name: 'Butcher's Block'
     potency: 130
     description: 'instant'
-  - name: 'Mad Charge (?)'
+  - name: 'Infusion'
     potency: 50 (x3)
     description: 'gap closer; hits 3 times, inflicting knockback each time'
   - name: 'Raging Rush (?)'

--- a/_hoh_091_enemies/nuppeppo_war.md
+++ b/_hoh_091_enemies/nuppeppo_war.md
@@ -6,16 +6,27 @@ image: nuppeppo_war.png
 start_floor: 91
 end_floor: 94
 agro: Sight
+hp: 69191
+attack_damage: 5690
+attack_type: Physical
 vulnerabilities:
   bind: true
   heavy: true
   sleep: false
   slow: true
   stun: true
+abilities:
+  - name: 'Poleaxe (?)'
+    potency: 130
+    description: 'instant'
+  - name: 'Mad Charge (?)'
+    potency: 50 (x3)
+    description: 'gap closer; hits 3 times, inflicting knockback each time'
+  - name: 'Raging Rush (?)'
+    potency: 300
+    description: 'telegraphed AoE?'
 notes:
-  - 'Does a tankbuster/knockback 3 times in a row'
-  - 'Has other very high damage attacks'
-  - 'Generally want to avoid these'
+  - 'Generally want to avoid these, as they deal a lot of damage'
 job_specifics:
   MCH:
     difficulty: 'Hard'

--- a/_hoh_091_enemies/nuppeppo_war.md
+++ b/_hoh_091_enemies/nuppeppo_war.md
@@ -16,7 +16,7 @@ vulnerabilities:
   slow: true
   stun: true
 abilities:
-  - name: 'Butcher's Block'
+  - name: 'Butcher''s Block'
     potency: 130
     description: 'instant'
   - name: 'Infusion'

--- a/_hoh_091_enemies/nuppeppo_whm.md
+++ b/_hoh_091_enemies/nuppeppo_whm.md
@@ -6,6 +6,10 @@ image: nuppeppo_whm.png
 start_floor: 91
 end_floor: 94
 agro: Sight
+hp: 69191
+attack_damage: 5992
+attack_type: Magic
+attack_name: Stone
 vulnerabilities:
   bind: true
   heavy: true
@@ -13,8 +17,6 @@ vulnerabilities:
   slow: unknown
   stun: true
 abilities:
-  - name: 'Stone'
-    description: 'used instead of auto-attacks; can be LoS''d'
   - name: 'Stoneskin'
     description: 'grants stoneskin; only used on other nearby enemies'
 notes:

--- a/_hoh_091_enemies/nuppeppo_whm.md
+++ b/_hoh_091_enemies/nuppeppo_whm.md
@@ -18,6 +18,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Stoneskin'
+    potency: n/a
     description: 'grants stoneskin; only used on other nearby enemies'
 notes:
   - 'You can pull these to a corner and LoS Stone casts to avoid all damage.

--- a/_hoh_091_enemies/shabti.md
+++ b/_hoh_091_enemies/shabti.md
@@ -5,6 +5,9 @@ image: shabti.png
 start_floor: 97
 end_floor: 99
 agro: Sight
+hp: 70086
+attack_damage: 6360
+attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
@@ -13,6 +16,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Death''s Door'
+    potency: 1500
     description: 'telegraphed line AoE; spams this a lot'
 job_specifics:
   DRK:

--- a/_hoh_091_enemies/tenma.md
+++ b/_hoh_091_enemies/tenma.md
@@ -6,6 +6,9 @@ image: tenma.png
 start_floor: 96
 end_floor: 99
 agro: Sight
+hp: 73669
+attack_damage: 5997
+attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
@@ -14,10 +17,13 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Rear Hoof'
-    description: 'tankbuster'
+    potency: 120
+    description: 'instant'
   - name: 'Burning Bright'
-    description: 'non-telegraphed line AoE - get to the side or behind'
+    potency: ?
+    description: 'untelegraphed long line AoE - get to the side or behind'
   - name: 'Nicker'
+    potency: ?
     description: 'telegraphed large pointblank AoE; can be interrupted'
 job_specifics:
   DRK:

--- a/_hoh_091_enemies/tenma.md
+++ b/_hoh_091_enemies/tenma.md
@@ -20,10 +20,8 @@ abilities:
     potency: 120
     description: 'instant'
   - name: 'Burning Bright'
-    potency: ?
     description: 'untelegraphed long line AoE - get to the side or behind'
   - name: 'Nicker'
-    potency: ?
     description: 'telegraphed large pointblank AoE; can be interrupted'
 job_specifics:
   DRK:

--- a/_hoh_091_enemies/zenki.md
+++ b/_hoh_091_enemies/zenki.md
@@ -17,7 +17,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Abyssal Swing
-    potency: ?
     description: telegraphed conal AoE
   - name: Abyssal Transfixion
     potency: 150

--- a/_hoh_091_enemies/zenki.md
+++ b/_hoh_091_enemies/zenki.md
@@ -6,6 +6,9 @@ image: zenki.png
 start_floor: 97
 end_floor: 99
 agro: Sight
+hp: 70086
+attack_damage: 5773
+attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
@@ -14,9 +17,11 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Abyssal Swing
+    potency: ?
     description: telegraphed conal AoE
   - name: Abyssal Transfixion
-    description: 'instant ranged tankbuster; does NOT paralyze like in PotD'
+    potency: 150
+    description: 'instant ranged attack; does NOT paralyze like in PotD'
 job_specifics:
   DRK:
     difficulty: 'Easy'

--- a/_hoh_floorsets/001.md
+++ b/_hoh_floorsets/001.md
@@ -11,12 +11,24 @@ respawns: '1m'
 hoard_type: Silver-haloed Sack
 boss: 'Mojabune'
 boss_image: mojabune.png
+boss_hp: 88592
+boss_attack_damage: 721
+boss_abilities:
+  - name: Concussive Oscillation
+    potency: 300
+    description: 'telegraphed circle AoE'
+  - name: Overtow
+    potency: 110
+    description: 'inflicts knockback; knockback immunity does not work'
+  - name: Amorphous Applause
+    potency: 250
+    description: 'telegraphed half room AoE'
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Concussive Oscillation: telegraphed circle AoE'
-      - 'Overtow: knockback from center; knockback immunity does not work'
-      - 'Amorphous Applause: telegraphed half room cleave'
+      - 'Concussive Oscillation'
+      - 'Overtow from center of room'
+      - 'Amorphous Applause'
 boss_job_specifics:
   AST:
     timing:

--- a/_hoh_floorsets/011.md
+++ b/_hoh_floorsets/011.md
@@ -11,18 +11,30 @@ respawns: '1m'
 hoard_type: Silver-haloed Sack
 boss: 'Beccho'
 boss_image: beccho.png
+boss_hp: 123156
+boss_attack_damage: 554
+boss_abilities:
+  - name: Proboscis
+    potency: 110
+    description: 'instant'
+  - name: Psycho Squama
+    potency: 500
+    description: 'huge conal AoE inflicting confused'
+  - name: Neuro Squama
+    description: '360 degree gaze inflicting confused (10s) - look away!'
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Proboscis: weak tank buster'
-      - 'Psycho Squama: huge conal AoE causing confusion'
       - 'Proboscis'
-      - note: 'Neuro Squama: 360 degree gaze causing confusion - look away!'
+      - 'Psycho Squama'
+      - 'Proboscis'
+      - note: 'Neuro Squama'
         subnotes:
           - 'Butterflies appear along the perimeter at the same time'
       - note: 'Psycho Squama'
         subnotes:
-          - 'Butterflies all explode at the same time'
+          - 'Butterflies all explode at the same time, inflicting big damage
+            and paralysis'
   - 'TLDR: Stay close to centre so everything is easy to dodge'
 boss_job_specifics:
   AST:

--- a/_hoh_floorsets/011.md
+++ b/_hoh_floorsets/011.md
@@ -21,6 +21,7 @@ boss_abilities:
     potency: 500
     description: 'huge conal AoE inflicting confused'
   - name: Neuro Squama
+    potency: n/a
     description: '360 degree gaze inflicting confused (10s) - look away!'
 boss_notes:
   - note: 'Rotation:'

--- a/_hoh_floorsets/021.md
+++ b/_hoh_floorsets/021.md
@@ -11,21 +11,44 @@ respawns: '1m'
 hoard_type: Silver-haloed Sack
 boss: 'Hiruko'
 boss_image: hiruko.png
+boss_hp: 187868
+boss_attack_damage: 926
+boss_abilities:
+  - name: Lightning Strike
+    potency: 350
+    description: 'telegraphed line AoE'
+  - name: Cloud Call
+    description: 'summons Raiuns (untargetable lightning cloud adds)'
+  - name: Shiko
+    potency: 100-1000
+    description: 'proximity AoE; knocks players into the air. Potency scales
+    from 1000 on top of the marker to 100 at ~3y distance (1 boss radius) from
+    the marker edge, so as long as you move a little bit away, damage is
+    minimal'
+  - name: Supercell
+    potency: 300
+    description: '180 degree AoE (covers the entire room in front of the boss)'
+  - name: '? (cloud AoE)'
+    potency: '125?'
+    description: 'telegraphed circle AoE; inflicts stacking vulnerability up
+    (20% per stack, 1m)'
 boss_notes:
   - note: 'Opening sequence:'
     subnotes:
-      - 'Lightning Strike: telegraphed line AoE'
-      - 'Cloud Call: summons many Raiuns (clouds)'
-      - 'Shiko: proximity AoE under the boss that knocks you into the air; make
-      sure you''re far from the boss and stand under a cloud. You will break
-      the cloud, creating a safe spot, as the other clouds will all do AoEs a
-      moment later - stay in the safe spot until after this'
+      - 'Lightning Strike'
+      - 'Cloud Call'
+      - note: 'Shiko'
+        subnotes:
+          - 'Make sure you''re far from the boss and stand under a cloud. You
+            will break the cloud, creating a safe spot, as the other clouds
+            will all do AoEs a moment later - stay in the safe spot until after
+            this'
       - 'Lightning Strike (wait until cloud AoEs before dodging)'
   - note: 'Rotation after opening sequence:'
     subnotes:
       - 'Lightning Strike'
       - 'Lightning Strike'
-      - 'Supercell: 180 degree huge AoE'
+      - 'Supercell'
       - 'Cloud Call'
       - 'Shiko'
       - 'Supercell (wait until cloud AoEs before dodging)'

--- a/_hoh_floorsets/031.md
+++ b/_hoh_floorsets/031.md
@@ -11,16 +11,39 @@ respawns: '10m'
 hoard_type: Gold-haloed Sack
 boss: 'Bhima'
 boss_image: bhima.png
+boss_hp: 185629
+boss_attack_damage: 955
+boss_abilities:
+  - name: Tornado
+    potency: 200
+    description: 'untelegraphed circle AoE'
+  - name: Ancient Aero
+    potency: 700
+    description: 'telegraphed line AoE; inflicts windburn (DoT potency 50,
+    30s)'
+  - name: Ancient Aero II
+    potency: 600
+    description: 'telegraphed circle AoE; inflicts windburn (DoT potency 50,
+    30s)'
+  - name: Ancient Aero III
+    potency: 100
+    description: 'roomwide AoE; inflicts knockback; knockback immunity does
+    not work, but completely blocking the damage with a shield will also
+    block the knockback'
+  - name: Windage (whirlwind adds)
+    potency: 600
+    description: 'pointblank AoE; inflicts windburn (DoT potency 50, 30s)'
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Tornado: circle AoE on target'
-      - 'Ancient Aero II: telegraphed circle AoE'
+      - 'Tornado'
+      - 'Ancient Aero II'
       - 'Whirlwinds appear along the west and east sides of the arena'
-      - 'Ancient Aero III: knockback; Whirlwinds explode immediately after
-      this, so make sure not get get knocked into them. Knockback immunity does
-      not work'
-      - 'Ancient Aero: telegraphed line AoE'
+      - note: 'Ancient Aero III'
+        subnotes:
+          - 'Whirlwinds explode immediately after this, so make sure not get
+            get knocked into them'
+      - 'Ancient Aero'
       - 'Ancient Aero II'
       - 'Whirlwinds appear along the north and south sides of the arena'
       - 'Ancient Aero III'

--- a/_hoh_floorsets/041.md
+++ b/_hoh_floorsets/041.md
@@ -11,20 +11,41 @@ respawns: '10m'
 hoard_type: Gold-haloed Sack
 boss: 'Gozu'
 boss_image: gozu.png
+boss_hp: 217202
+boss_attack_damage: 1119
+boss_abilities:
+  - name: Rusting Claw
+    potency: 600
+    description: 'untelegraphed conal AoE; inflicts stacking vulnerability up
+    (20% per stack, 1m)'
+  - name: Words of Woe
+    potency: 600
+    description: 'untelegraphed line AoE; inflicts stacking vulnerability up
+    (20% per stack, 1m)'
+  - name: Eye of the Fire
+    description: '360 degree gaze inflicting confused (20s) - look away'
+  - name: The Spin
+    potency: 150-2000
+    description: 'proximity AoE - get away (need to be about half the room
+    away for minimum potency)'
+  - name: Void Spark (orb adds)
+    potency: 150
+    description: 'telegraphed pointblank AoE; inflicts heavy (30s). Diminishing
+    returns do NOT apply to this heavy (it is always 30s)'
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Rusting Claw: non-telegraphed conal AoE. He stops and raises a hand to
-      indicate that he''s readying this'
-      - 'Words of Woe: non-telegraphed line AoE. He stops, looks at the target,
-      and stands still for a moment before firing this'
-      - 'Eye of the Fire: 360 degree gaze causing confusion - look away'
+      - 'Rusting Claw - he stops and raises a hand to indicate that he''s
+      readying this'
+      - 'Words of Woe - he stops, looks at the target, and stands still for a
+      moment before firing this'
+      - 'Eye of the Fire'
       - 'Orbs appear and boss drops proximity marker. Orbs will do telegraphed
       pointblank AoEs at regular intervals. Get away from the boss, but also
       away from the orbs'
-      - 'The Spin: proximity AoE - big damage if you''re close to the marker,
-      and very little if you''re half the room away'
-      - 'Orbs disappear as he does his next conal AoE'
+      - 'The Spin - big damage if you''re close to the marker, and very little
+      if you''re half the room away'
+      - 'Orbs disappear as he does his next Rusting Claw'
 boss_job_specifics:
   AST:
     timing:

--- a/_hoh_floorsets/051.md
+++ b/_hoh_floorsets/051.md
@@ -15,22 +15,17 @@ boss_hp: 518822
 boss_attack_damage: 2648
 boss_abilities:
   - name: Firewalker
-    potency: ?
     description: 'telegraphed conal AoE'
   - name: Fire II
-    potency: ?
     description: 'telegraphed circle AoE'
   - name: Topple
-    potency: ?
     description: 'telegraphed pointblank AoE'
   - name: Ancient Flare
     potency: 180
     description: 'roomwide AoE'
   - name: Infinite Anguish (staff adds)
-    potency: ?
     description: 'telegraphed donut AoE'
   - name: Searing Chain (staff adds)
-    potency: ?
     description: 'telegraphed line AoE'
 boss_notes:
   - note: 'Rotation:'

--- a/_hoh_floorsets/051.md
+++ b/_hoh_floorsets/051.md
@@ -11,23 +11,43 @@ respawns: '10m'
 hoard_type: Gold-haloed Sack
 boss: 'Suikazura'
 boss_image: suikazura.png
+boss_hp: 518822
+boss_attack_damage: 2648
+boss_abilities:
+  - name: Firewalker
+    potency: ?
+    description: 'telegraphed conal AoE'
+  - name: Fire II
+    potency: ?
+    description: 'telegraphed circle AoE'
+  - name: Topple
+    potency: ?
+    description: 'telegraphed pointblank AoE'
+  - name: Ancient Flare
+    potency: 180
+    description: 'roomwide AoE'
+  - name: Infinite Anguish (staff adds)
+    potency: ?
+    description: 'telegraphed donut AoE'
+  - name: Searing Chain (staff adds)
+    potency: ?
+    description: 'telegraphed line AoE'
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Firewalker: telegraphed conal AoE'
+      - 'Firewalker'
       - 'First set of 4 Accursed Canes appears'
       - 'Second set of 4 Accursed Canes appears'
-      - 'Fire II: telegraphed circle AoE. At the same time, the first group of
-      canes does donut AoEs'
+      - 'Fire II - at the same time, the first group of canes does donut AoEs'
       - 'Second set of canes does donut AoEs'
-      - 'Topple: telegraphed pointblank AoE. At the same time, the first group
-      of canes does line AoEs at random players'
+      - 'Topple - At the same time, the first group of canes does line AoEs at
+      random players'
       - 'Second group of canes does line AoEs'
       - 'Canes disappear and a new group of 8 appears'
       - 'Fire II'
       - 'All 8 canes do donut AoEs. The centre is always safe from these, and
       there are safe spots to the outside of each cane'
-      - 'Ancient Flare: roomwide AoE'
+      - 'Ancient Flare'
       - 'All 8 canes do line AoEs at random players. These are easiest to dodge
       if you bait them toward the walls'
   - 'TLDR: Lots of AoEs to dodge'

--- a/_hoh_floorsets/061.md
+++ b/_hoh_floorsets/061.md
@@ -33,7 +33,7 @@ boss_abilities:
   - name: Devour
     potency: 2500?
     description: 'instant death to players WITHOUT minimum debuff (otherwise
-    misses); on hit, absorbs target's remaining HP'
+    misses); on hit, absorbs target''s remaining HP'
 boss_notes:
   - note: 'Rotation:'
     subnotes:

--- a/_hoh_floorsets/061.md
+++ b/_hoh_floorsets/061.md
@@ -31,8 +31,9 @@ boss_abilities:
     description: 'telegraphed wide charge AoE to targeted player; inflicts
     stun (4s)'
   - name: Devour
-    description: 'instant death to players WITHOUT minimum debuff (otherwise no
-    damage)'
+    potency: 2500?
+    description: 'instant death to players WITHOUT minimum debuff (otherwise
+    misses); on hit, absorbs target's remaining HP'
 boss_notes:
   - note: 'Rotation:'
     subnotes:

--- a/_hoh_floorsets/061.md
+++ b/_hoh_floorsets/061.md
@@ -11,21 +11,38 @@ respawns: '10m'
 hoard_type: Gold-haloed Sack
 boss: 'Kenko'
 boss_image: kenko.png
+boss_hp: '650000 (approx.)'
+boss_attack_damage: 2931
+boss_abilities:
+  - name: Predator Claws
+    potency: 600
+    description: 'untelegraphed conal AoE - get away or behind'
+  - name: Slabber
+    potency: 450
+    description: 'telegraphed circle AoE'
+  - name: Innerspace
+    potency: 90
+    description: 'targeted circle AoE; leaves a puddle that inflicts minimum'
+  - name: Ululation
+    potency: 110
+    description: 'roomwide AoE; instant death to players with minimum debuff'
+  - name: Hound out of Hell
+    potency: 50
+    description: 'telegraphed wide charge AoE to targeted player; inflicts
+    stun (4s)'
+  - name: Devour
+    description: 'instant death to players WITHOUT minimum debuff (otherwise no
+    damage)'
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Predator Claws: non-telegraphed conal AoE - get away or behind'
-      - 'Slabber: telegraphed circle AoE'
-      - 'Innerspace: circle AoE on targeted player; leaves a puddle that causes
-      mini'
-      - 'Ululation: roomwide AoE; instant death if you are mini (stay OUT of
-      puddle until after this)'
-      - 'Hound out of Hell: telegraphed charge AoE to targeted player; causes
-      stun; instant death if you are NOT mini; get IN the puddle when this
-      targets you'
-      - 'Devour: instant death if you are NOT mini; get OUT of the puddle after
-      this'
-      - 'Ululation (make sure you''re OUT of puddle)'
+      - 'Predator Claws'
+      - 'Slabber'
+      - 'Innerspace'
+      - 'Ululation - stay OUT of puddle until after this'
+      - 'Hound out of Hell - get IN the puddle when this targets you'
+      - 'Devour - stay IN puddle until this, then get OUT'
+      - 'Ululation - make sure you''re OUT of puddle'
   - 'TLDR: Be OUT of puddle for Ululation > IN for Hound out of Hell and
   Devour > OUT for Ululation'
   - 'Innerspace targets a random player each round. Hound out of Hell and

--- a/_hoh_floorsets/071.md
+++ b/_hoh_floorsets/071.md
@@ -15,7 +15,6 @@ boss_hp: 701000
 boss_attack_damage: 2975
 boss_abilities:
   - name: Heavensward Howl
-    potency: '?'
     description: 'telegraphed conal AoE'
   - name: Eclipse Bite
     potency: 100

--- a/_hoh_floorsets/071.md
+++ b/_hoh_floorsets/071.md
@@ -11,17 +11,29 @@ respawns: '10m'
 hoard_type: Platinum-haloed Sack
 boss: Kajigakaka
 boss_image: kajigakaka.png
+boss_hp: 701000
+boss_attack_damage: 2975
+boss_abilities:
+  - name: Heavensward Howl
+    potency: '?'
+    description: 'telegraphed conal AoE'
+  - name: Eclipse Bite
+    potency: 100
+    description: 'instant gap closer'
+  - name: Lunar Cry
+    potency: 100
+    description: 'roomwide AoE'
 boss_notes:
   - note: 'Rotation:'
     subnotes:
-      - 'Heavensward Howl: telegraphed conal AoE'
-      - 'Eclipse Bite: tankbuster/gap closer'
-      - 'Summons ice chunks that will explode in a large non-telegraphed
+      - 'Heavensward Howl'
+      - 'Eclipse Bite'
+      - 'Summons ice chunks that will explode in a large untelegraphed
       pointblank AoE if hit by the icicle, other exploding chunks, or Lunar
       Cry'
       - 'Icicle appears on one side of the arena with telegraphed circle AoE,
       then does a telegraphed line AoE shooting across the platform'
-      - 'Lunar Cry: roomwide AoE'
+      - 'Lunar Cry'
       - 'Eclipse Bite'
 boss_job_specifics:
   AST:

--- a/_hoh_floorsets/081.md
+++ b/_hoh_floorsets/081.md
@@ -11,19 +11,36 @@ respawns: '10m'
 hoard_type: Platinum-haloed Sack
 boss: Onra
 boss_image: onra.png
+boss_hp: 791055
+boss_attack_damage: 3787
+boss_abilities:
+  - name: Burning Rave
+    potency: '?'
+    description: 'telegraphed circle AoE'
+  - name: Knuckle Press
+    potency: '?'
+    description: 'telegraphed pointblank AoE'
+  - name: Aura Cannon
+    potency: '?'
+    description: 'telegraphed wide line AoE'
+  - name: Ancient Quaga
+    potency: 50% of max HP
+    description: 'roomwide AoE'
+  - name: Meteor Impact
+    description: 'delayed proximity AoE'
 boss_notes:
   - note: 'Rotation before 85%:'
     subnotes:
-      - 'Burning Rave: telegraphed circle AoE'
-      - 'Knuckle Press: telegraphed pointblank AoE'
-      - 'Aura Cannon: telegraphed wide line AoE'
+      - 'Burning Rave'
+      - 'Knuckle Press'
+      - 'Aura Cannon'
   - note: 'Rotation after 85%:'
     subnotes:
-      - 'Ancient Quaga: roomwide 50% max HP damage'
-      - 'Meteor Impact: drops proximity marker under Onra; several black orbs
+      - 'Ancient Quaga'
+      - 'Meteor Impact - drops proximity marker under Onra; several black orbs
       also spawn around the room and pulse pointblank AoEs that cause heavy'
       - 'Aura Cannon'
-      - 'Burning Rave; meteor drops on proximity marker, and black orbs
+      - 'Burning Rave - meteor drops on proximity marker, and black orbs
       disappear roughly when this cast starts'
       - 'Knuckle Press'
   - note: 'Melee uptime strategy:'

--- a/_hoh_floorsets/081.md
+++ b/_hoh_floorsets/081.md
@@ -15,13 +15,10 @@ boss_hp: 791055
 boss_attack_damage: 3787
 boss_abilities:
   - name: Burning Rave
-    potency: '?'
     description: 'telegraphed circle AoE'
   - name: Knuckle Press
-    potency: '?'
     description: 'telegraphed pointblank AoE'
   - name: Aura Cannon
-    potency: '?'
     description: 'telegraphed wide line AoE'
   - name: Ancient Quaga
     potency: 50% of max HP

--- a/_potd_001_enemies/bat.md
+++ b/_potd_001_enemies/bat.md
@@ -19,5 +19,6 @@ abilities:
     potency: 100
     description: 'pierces Steel; absorbs 50% of damage dealt'
   - name: Ultrasonics
+    potency: n/a
     description: 'telegraphed conal AoE; inflicts accuracy down (12s)'
 ---

--- a/_potd_001_enemies/beetle.md
+++ b/_potd_001_enemies/beetle.md
@@ -16,5 +16,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Spoil
+    potency: n/a
     description: 'inflicts poison (DoT potency 20, 15s)'
 ---

--- a/_potd_001_enemies/deathmouse.md
+++ b/_potd_001_enemies/deathmouse.md
@@ -16,5 +16,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Scamper
+    potency: n/a
     description: 'grants haste (30s) to self'
 ---

--- a/_potd_001_enemies/mimic.md
+++ b/_potd_001_enemies/mimic.md
@@ -17,6 +17,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_potd_001_enemies/yarzon.md
+++ b/_potd_001_enemies/yarzon.md
@@ -16,5 +16,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Corrosive Spit (?)'
+    potency: n/a
     description: 'instant; inflicts physical vulnerability up (50%, 20s)'
 ---

--- a/_potd_001_enemies/ziz.md
+++ b/_potd_001_enemies/ziz.md
@@ -17,5 +17,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Slumber Breath
+    potency: n/a
     description: 'telegraphed conal AoE; inflicts sleep (20s)'
 ---

--- a/_potd_011_enemies/cobra.md
+++ b/_potd_011_enemies/cobra.md
@@ -16,6 +16,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Stone Gaze
+    potency: n/a
     description: '360 degree gaze inflicting petrify (15s) - look away'
   - name: Devour
     potency: 100% of max HP

--- a/_potd_011_enemies/mimic.md
+++ b/_potd_011_enemies/mimic.md
@@ -17,6 +17,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_potd_011_enemies/morbol.md
+++ b/_potd_011_enemies/morbol.md
@@ -16,6 +16,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Bad Breath
+    potency: n/a
     description: 'large telegraphed conal AoE; inflicts many debuffs'
 notes:
   - note: 'Bad Breath inflicts these debuffs:'

--- a/_potd_011_enemies/ochu.md
+++ b/_potd_011_enemies/ochu.md
@@ -16,5 +16,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Acid Mist
+    potency: n/a
     description: 'inflicts slow (12s)'
 ---

--- a/_potd_011_enemies/pudding.md
+++ b/_potd_011_enemies/pudding.md
@@ -18,6 +18,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Golden Tongue
+    potency: n/a
     description: 'grants magic damage up (50%, 15s) to self'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'

--- a/_potd_011_enemies/slime.md
+++ b/_potd_011_enemies/slime.md
@@ -20,6 +20,6 @@ abilities:
     description: 'absorbs 100% of damage dealt'
   - name: Rapture
     potency: 170% of max HP
-    description: 'instant AoE sacrificial enrage; used 20 seconds after
-    pull/aggro (immediately after the second Digest)'
+    description: 'instant AoE sacrificial enrage; used 20 seconds after pull
+    (immediately after the second Digest)'
 ---

--- a/_potd_011_enemies/uragnite.md
+++ b/_potd_011_enemies/uragnite.md
@@ -16,5 +16,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Gas Shell (?)'
+    potency: n/a
     description: 'inflicts poison (DoT potency 30, 12s)'
 ---

--- a/_potd_021_enemies/centaur.md
+++ b/_potd_021_enemies/centaur.md
@@ -16,6 +16,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Berserk
+    potency: n/a
     description: 'grants damage up (50%, 20s) to self'
   - name: Rear
     potency: 200

--- a/_potd_021_enemies/drake.md
+++ b/_potd_021_enemies/drake.md
@@ -16,5 +16,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Smoldering Scales
+    potency: n/a
     description: 'grants counterattack (potency 200, 5s) to self'
 ---

--- a/_potd_021_enemies/mimic.md
+++ b/_potd_021_enemies/mimic.md
@@ -17,6 +17,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_potd_021_enemies/peiste.md
+++ b/_potd_021_enemies/peiste.md
@@ -16,6 +16,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Stone Gaze
+    potency: n/a
     description: 'telegraphed conal gaze AoE inflicting petrify (15s) - look
     away, get behind, or get away'
 ---

--- a/_potd_021_enemies/skatene.md
+++ b/_potd_021_enemies/skatene.md
@@ -16,5 +16,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Chirp
+    potency: n/a
     description: 'untelegraphed large pointblank AoE; inflicts sleep (15s)'
 ---

--- a/_potd_021_enemies/spriggan.md
+++ b/_potd_021_enemies/spriggan.md
@@ -17,6 +17,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Haste
+    potency: n/a
     description: 'grants haste (30s) to self'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'

--- a/_potd_031_enemies/catoblepas.md
+++ b/_potd_031_enemies/catoblepas.md
@@ -16,6 +16,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Quarry Lake
+    potency: n/a
     description: 'telegraphed conal gaze AoE inflicting petrify (15s) - look
     away, get behind, or get away'
 ---

--- a/_potd_031_enemies/mimic.md
+++ b/_potd_031_enemies/mimic.md
@@ -17,6 +17,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_potd_031_enemies/monk.md
+++ b/_potd_031_enemies/monk.md
@@ -18,6 +18,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Sucker
+    potency: n/a
     description: 'large untelegraphed pointblank AoE; draws players in'
   - name: Flood
     potency: 250

--- a/_potd_041_enemies/bhoot.md
+++ b/_potd_041_enemies/bhoot.md
@@ -16,6 +16,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Paralyze III'
+    potency: n/a
     description: 'huge untelegraphed pointblank AoE inflicting paralysis (15s);
     can be interrupted'
 ---

--- a/_potd_041_enemies/knight.md
+++ b/_potd_041_enemies/knight.md
@@ -16,5 +16,6 @@ vulnerabilities:
   stun: true
 abilities:
   - name: Ossify
+    potency: n/a
     description: 'grants damage up (100%, 8s) to self'
 ---

--- a/_potd_041_enemies/mimic.md
+++ b/_potd_041_enemies/mimic.md
@@ -17,6 +17,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_potd_041_enemies/persona.md
+++ b/_potd_041_enemies/persona.md
@@ -16,6 +16,7 @@ vulnerabilities:
   stun: true
 abilities:
   - name: 'Paralyze III'
+    potency: n/a
     description: 'huge untelegraphed pointblank AoE inflicting paralysis (15s);
     can be interrupted'
 ---

--- a/_potd_051_enemies/deepeye.md
+++ b/_potd_051_enemies/deepeye.md
@@ -20,5 +20,6 @@ abilities:
     potency: 130
     description: 'instant'
   - name: Hypnotize
+    potency: n/a
     description: 'roomwide gaze attack inflicting paralysis (30s) - look away'
 ---

--- a/_potd_051_enemies/gremlin.md
+++ b/_potd_051_enemies/gremlin.md
@@ -17,6 +17,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Bad Mouth
+    potency: n/a
     description: 'instant; inflicts vulnerability up (25%, 10s)'
   - name: Fire II
     potency: 300

--- a/_potd_051_enemies/imp.md
+++ b/_potd_051_enemies/imp.md
@@ -18,6 +18,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Ice Spikes
+    potency: n/a
     description: 'grants counterattack (potency 200, 5s) to self; can be
     interrupted'
 notes:

--- a/_potd_051_enemies/mimic.md
+++ b/_potd_051_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_potd_051_enemies/pudding.md
+++ b/_potd_051_enemies/pudding.md
@@ -18,6 +18,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Golden Tongue
+    potency: n/a
     description: 'grants magic damage up (50%, 15s) to self'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'

--- a/_potd_051_enemies/soulflayer.md
+++ b/_potd_051_enemies/soulflayer.md
@@ -20,6 +20,7 @@ abilities:
     potency: 300
     description: 'telegraphed pointblank AoE; inflicts paralysis (15s)'
   - name: 'Canker (?)'
+    potency: n/a
     description: 'instant enrage; inflicts disease (15s) with strong heavy
     effect'
 notes:

--- a/_potd_061_enemies/diplocaulus.md
+++ b/_potd_061_enemies/diplocaulus.md
@@ -17,6 +17,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Foregone Gleam
+    potency: n/a
     description: 'untelegraphed conal gaze AoE inflicting paralysis (20s) -
     look away, get behind, or get away'
 ---

--- a/_potd_061_enemies/mimic.md
+++ b/_potd_061_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_potd_071_enemies/anzu.md
+++ b/_potd_071_enemies/anzu.md
@@ -18,6 +18,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: 'Sonic Boom (?)'
+    potency: n/a
     description: 'instant; inflicts windburn (DoT potency 30, 20s)'
   - name: Flying Frenzy
     potency: 180

--- a/_potd_071_enemies/anzu.md
+++ b/_potd_071_enemies/anzu.md
@@ -22,5 +22,6 @@ abilities:
   - name: Flying Frenzy
     potency: 180
     description: 'instant circle AoE gap closer; inflicts stun (2s) and
-    vulnerability up (50%, 10s); used when HP is below 30%'
+    vulnerability up (50%, 10s); used when HP is below 30%. Diminishing returns
+    do NOT apply to this stun (it is always 2s)'
 ---

--- a/_potd_071_enemies/dhalmel.md
+++ b/_potd_071_enemies/dhalmel.md
@@ -20,5 +20,6 @@ abilities:
     potency: 300
     description: 'telegraphed conal AoE'
   - name: Whistle
+    potency: n/a
     description: 'grants physical damage up (50%, 15s) to self'
 ---

--- a/_potd_071_enemies/mimic.md
+++ b/_potd_071_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_potd_071_enemies/sasquatch.md
+++ b/_potd_071_enemies/sasquatch.md
@@ -20,6 +20,7 @@ abilities:
     potency: 300
     description: 'telegraphed circle AoE'
   - name: Ripe Banana
+    potency: n/a
     description: 'grants physical damage up (100%, 15s) to self and heals 80%
     of max HP; only used out of combat'
 ---

--- a/_potd_081_enemies/bomb.md
+++ b/_potd_081_enemies/bomb.md
@@ -18,6 +18,5 @@ vulnerabilities:
 abilities:
   - name: 'Self-destruct'
     potency: 70% of max HP
-    description: 'instant AoE sacrifical enrage; used 37 seconds after
-    pull/aggro'
+    description: 'instant AoE sacrifical enrage; used 37 seconds after pull'
 ---

--- a/_potd_081_enemies/claw.md
+++ b/_potd_081_enemies/claw.md
@@ -18,6 +18,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: 'Inspire (?)'
+    potency: n/a
     description: 'instant; draws the target in and inflicts prey. Knockback
     immunity does not work against the draw-in'
   - name: Impale

--- a/_potd_081_enemies/mimic.md
+++ b/_potd_081_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_potd_091_enemies/knight.md
+++ b/_potd_091_enemies/knight.md
@@ -17,5 +17,6 @@ vulnerabilities:
   resolution: true
 abilities:
   - name: Ossify
+    potency: n/a
     description: 'grants damage up (100%, 8s) to self'
 ---

--- a/_potd_091_enemies/mimic.md
+++ b/_potd_091_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_potd_101_enemies/beetle.md
+++ b/_potd_101_enemies/beetle.md
@@ -21,5 +21,6 @@ abilities:
     potency: 250
     description: 'gap closer (can be LoSed)'
   - name: Rhino Guard
+    potency: n/a
     description: 'grants evasion up (8s) to self'
 ---

--- a/_potd_101_enemies/gaelicat.md
+++ b/_potd_101_enemies/gaelicat.md
@@ -20,6 +20,7 @@ abilities:
     potency: 130
     description: 'instant'
   - name: Yowl
+    potency: n/a
     description: 'telegraphed conal AoE; inflicts physical damage down (90%,
     15s)'
 ---

--- a/_potd_101_enemies/ladybug.md
+++ b/_potd_101_enemies/ladybug.md
@@ -17,5 +17,6 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Spoil
+    potency: n/a
     description: 'inflicts poison (DoT potency 20, 15s)'
 ---

--- a/_potd_101_enemies/mimic.md
+++ b/_potd_101_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_potd_101_enemies/squirrel.md
+++ b/_potd_101_enemies/squirrel.md
@@ -17,6 +17,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Scamper
+    potency: n/a
     description: 'grants haste (30s) to self'
 notes:
   - 'Arm''s Length can be used to override the haste buff and prevent it from

--- a/_potd_101_enemies/yarzon.md
+++ b/_potd_101_enemies/yarzon.md
@@ -17,5 +17,6 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: 'Corrosive Spit (?)'
+    potency: n/a
     description: 'instant; inflicts physical vulnerability up (50%, 20s)'
 ---

--- a/_potd_101_enemies/ziz.md
+++ b/_potd_101_enemies/ziz.md
@@ -18,5 +18,6 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Numbing Breath
+    potency: n/a
     description: 'telegraphed conal AoE; inflicts paralysis (15s)'
 ---

--- a/_potd_111_enemies/biloko.md
+++ b/_potd_111_enemies/biloko.md
@@ -21,6 +21,7 @@ abilities:
     potency: 300
     description: 'telegraphed conal AoE'
   - name: Stoneskin
+    potency: n/a
     description: 'grants stoneskin (10% of max HP, 60s) to a nearby enemy; not
     used on self'
 ---

--- a/_potd_111_enemies/mimic.md
+++ b/_potd_111_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_potd_111_enemies/morbol.md
+++ b/_potd_111_enemies/morbol.md
@@ -17,9 +17,11 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: 'Sweet Breath (?)'
+    potency: n/a
     description: 'large instant conal AoE; inflicts sleep (3s) and slow (10s);
     used immediately before Bad Breath'
   - name: Bad Breath
+    potency: n/a
     description: 'large telegraphed conal AoE; inflicts many debuffs'
 notes:
   - 'Stand close if solo or tanking, so you''ll be able to get out of the Bad

--- a/_potd_111_enemies/ochu.md
+++ b/_potd_111_enemies/ochu.md
@@ -17,6 +17,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Gold Dust
+    potency: n/a
     description: 'telegraphed large circle AoE; inflicts poison (DoT potency
     60, 15s)'
 ---

--- a/_potd_111_enemies/salamander.md
+++ b/_potd_111_enemies/salamander.md
@@ -17,6 +17,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Mucin
+    potency: n/a
     description: 'grants stoneskin (1/3 of max HP, 8s) to self; can be
     interrupted'
 ---

--- a/_potd_111_enemies/slime.md
+++ b/_potd_111_enemies/slime.md
@@ -19,8 +19,7 @@ vulnerabilities:
 abilities:
   - name: 'Rapture'
     potency: 100% of max HP
-    description: 'instant AoE sacrificial enrage; used 37 seconds after
-    pull/aggro'
+    description: 'instant AoE sacrificial enrage; used 37 seconds after pull'
 notes:
   - 'Acid Spray inflicts stacking physical vulnerability up (+10% per stack,
     max 8 stacks, 5s); this ability does magic damage, so its own damage is

--- a/_potd_121_enemies/adamantoise.md
+++ b/_potd_121_enemies/adamantoise.md
@@ -20,5 +20,6 @@ abilities:
     potency: 500
     description: 'large telegraphed pointblank AoE'
   - name: 'Strengthen Shell (?)'
+    potency: n/a
     description: 'grants physical vulnerability down (90%, 20s) to self'
 ---

--- a/_potd_121_enemies/basilisk.md
+++ b/_potd_121_enemies/basilisk.md
@@ -21,6 +21,7 @@ abilities:
     potency: 300
     description: 'telegraphed pointblank AoE'
   - name: Stone Gaze
+    potency: n/a
     description: 'telegraphed conal gaze AoE inflicting petrify (15s) - look
     away, get behind, or get away'
 ---

--- a/_potd_121_enemies/centaur.md
+++ b/_potd_121_enemies/centaur.md
@@ -17,6 +17,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Berserk
+    potency: n/a
     description: 'grants damage up (50%, 20s) to self'
   - name: Rear
     potency: 300

--- a/_potd_121_enemies/dullahan.md
+++ b/_potd_121_enemies/dullahan.md
@@ -21,5 +21,5 @@ abilities:
     potency: 300
     description: 'telegraphed conal AoE'
   - name: 'Suffering Blade (?)'
-    description: 'causes autoattacks to absorb 100% of damage dealt for 30s'
+    description: 'causes auto-attacks to absorb 100% of damage dealt for 30s'
 ---

--- a/_potd_121_enemies/dullahan.md
+++ b/_potd_121_enemies/dullahan.md
@@ -21,5 +21,6 @@ abilities:
     potency: 300
     description: 'telegraphed conal AoE'
   - name: 'Suffering Blade (?)'
+    potency: n/a
     description: 'causes auto-attacks to absorb 100% of damage dealt for 30s'
 ---

--- a/_potd_121_enemies/mimic.md
+++ b/_potd_121_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_potd_121_enemies/sketene.md
+++ b/_potd_121_enemies/sketene.md
@@ -18,5 +18,6 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Chirp
+    potency: n/a
     description: 'untelegraphed large pointblank AoE; inflicts sleep (15s)'
 ---

--- a/_potd_121_enemies/spriggan.md
+++ b/_potd_121_enemies/spriggan.md
@@ -21,6 +21,7 @@ abilities:
     potency: 300
     description: 'telegraphed circle AoE; also used out of combat'
   - name: Haste
+    potency: n/a
     description: 'grants haste (30s) to self'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'

--- a/_potd_131_enemies/ahriman.md
+++ b/_potd_131_enemies/ahriman.md
@@ -19,6 +19,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Level 5 Petrify
+    potency: n/a
     description: 'untelegraphed conal AoE inflicting petrify (15s) - get behind
     or get away'
 notes:

--- a/_potd_131_enemies/catoblepas.md
+++ b/_potd_131_enemies/catoblepas.md
@@ -18,6 +18,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Eye of the Stunted
+    potency: n/a
     description: 'telegraphed conal gaze AoE inflicting minimum (30s) - look
     away, get behind, or get away'
   - name: 'Jettatura'

--- a/_potd_131_enemies/mimic.md
+++ b/_potd_131_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_potd_131_enemies/monk.md
+++ b/_potd_131_enemies/monk.md
@@ -19,6 +19,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Sucker
+    potency: n/a
     description: 'large untelegraphed pointblank AoE; draws players in'
   - name: Flood
     potency: 350

--- a/_potd_131_enemies/taurus.md
+++ b/_potd_131_enemies/taurus.md
@@ -20,6 +20,7 @@ abilities:
     potency: 120
     description: 'instant'
   - name: Voidblood
+    potency: n/a
     description: 'telegraphed circle AoE that inflicts Voidblood (increases
     damage taken); not used vs. solo adventurers'
 ---

--- a/_potd_141_enemies/bhoot.md
+++ b/_potd_141_enemies/bhoot.md
@@ -17,6 +17,7 @@ vulnerabilities:
   resolution: true
 abilities:
   - name: 'Paralyze III'
+    potency: n/a
     description: 'huge untelegraphed pointblank AoE inflicting paralysis (15s);
     can be interrupted'
 job_specifics:

--- a/_potd_141_enemies/knight.md
+++ b/_potd_141_enemies/knight.md
@@ -20,6 +20,7 @@ abilities:
     potency: 130
     description: 'instant'
   - name: Ossify
+    potency: n/a
     description: 'grants damage up (100%, 8s) to self'
 notes:
   - 'Hits pretty hard with the attack bonus'

--- a/_potd_141_enemies/manticore.md
+++ b/_potd_141_enemies/manticore.md
@@ -21,6 +21,7 @@ abilities:
     potency: 130
     description: 'instant gap closer'
   - name: 'Enrage (?)'
+    potency: n/a
     description: 'grants damage up (50%, 30s) to self; used immediately after
     Wild Charge. When the buff expires, it changes to a physical damage down
     debuff (60%, 30s)'

--- a/_potd_141_enemies/manticore.md
+++ b/_potd_141_enemies/manticore.md
@@ -19,7 +19,8 @@ vulnerabilities:
 abilities:
   - name: Wild Charge
     potency: 130
-    description: 'instant gap closer'
+    description: 'instant gap closer; used immediately on pull, and again when
+    its damage down debuff (see next ability) wears off'
   - name: 'Enrage (?)'
     potency: n/a
     description: 'grants damage up (50%, 30s) to self; used immediately after

--- a/_potd_141_enemies/mimic.md
+++ b/_potd_141_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_potd_141_enemies/persona.md
+++ b/_potd_141_enemies/persona.md
@@ -17,6 +17,7 @@ vulnerabilities:
   resolution: true
 abilities:
   - name: 'Paralyze III'
+    potency: n/a
     description: 'huge untelegraphed pointblank AoE inflicting paralysis (15s);
     can be interrupted'
 job_specifics:

--- a/_potd_151_enemies/abaia.md
+++ b/_potd_151_enemies/abaia.md
@@ -18,8 +18,10 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Terror Eye
+    potency: n/a
     description: 'telegraphed circle AoE; also used out of combat'
   - name: 'Resonate (?)'
+    potency: n/a
     description: 'grants physical damage up (80%, 30s) to self; used 47 seconds
     after pull'
 job_specifics:

--- a/_potd_151_enemies/abaia.md
+++ b/_potd_151_enemies/abaia.md
@@ -21,7 +21,7 @@ abilities:
     description: 'telegraphed circle AoE; also used out of combat'
   - name: 'Resonate (?)'
     description: 'grants physical damage up (80%, 30s) to self; used 47 seconds
-    after pull/aggro'
+    after pull'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_151_enemies/deepeye.md
+++ b/_potd_151_enemies/deepeye.md
@@ -20,6 +20,7 @@ abilities:
     potency: 130
     description: 'instant'
   - name: Hypnotize
+    potency: n/a
     description: 'roomwide gaze attack inflicting paralysis (30s) - look away'
 job_specifics:
   GNB:

--- a/_potd_151_enemies/devilet.md
+++ b/_potd_151_enemies/devilet.md
@@ -19,6 +19,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Ice Spikes
+    potency: n/a
     description: 'Grants counterattack (potency 200, 5s) to self; can be
     interrupted. Recommended to interrupt or disengage immediately. The damage
     can kill you very quickly'

--- a/_potd_151_enemies/devilet.md
+++ b/_potd_151_enemies/devilet.md
@@ -31,7 +31,7 @@ notes:
     probably the safest option as you avoid all damage'
   - 'Some people prefer to disengage during Ice Spikes and stun/interrupt Void
     Blizzard. Make sure to disengage again quickly, but you will probably still
-    get one autoattack in and take Ice Spikes damage.'
+    get one auto-attack in and take Ice Spikes damage.'
   - 'Can be slowed if transfigured via Pomander of Witching'
 job_specifics:
   GNB:

--- a/_potd_151_enemies/gremlin.md
+++ b/_potd_151_enemies/gremlin.md
@@ -17,6 +17,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Bad Mouth
+    potency: n/a
     description: 'instant; inflicts vulnerability up (25%, 10s)'
   - name: Fire II
     potency: 300

--- a/_potd_151_enemies/mimic.md
+++ b/_potd_151_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_potd_161_enemies/archaeosaur.md
+++ b/_potd_161_enemies/archaeosaur.md
@@ -20,6 +20,7 @@ abilities:
     potency: 130
     description: 'instant'
   - name: Primordial Bark
+    potency: ?
     description: 'telegraphed pointblank AoE'
 notes:
   - Hits pretty hard

--- a/_potd_161_enemies/archaeosaur.md
+++ b/_potd_161_enemies/archaeosaur.md
@@ -20,7 +20,6 @@ abilities:
     potency: 130
     description: 'instant'
   - name: Primordial Bark
-    potency: ?
     description: 'telegraphed pointblank AoE'
 notes:
   - Hits pretty hard

--- a/_potd_161_enemies/diplocaulus.md
+++ b/_potd_161_enemies/diplocaulus.md
@@ -21,6 +21,7 @@ abilities:
     description: 'grants stoneskin (1/3 of max HP, 8s) to self; can be
     interrupted'
   - name: Foregone Gleam
+    potency: ?
     description: 'untelegraphed conal gaze AoE - look away, get behind, or get
     away'
 job_specifics:

--- a/_potd_161_enemies/diplocaulus.md
+++ b/_potd_161_enemies/diplocaulus.md
@@ -18,10 +18,10 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Mucin
+    potency: n/a
     description: 'grants stoneskin (1/3 of max HP, 8s) to self; can be
     interrupted'
   - name: Foregone Gleam
-    potency: ?
     description: 'untelegraphed conal gaze AoE - look away, get behind, or get
     away'
 job_specifics:

--- a/_potd_161_enemies/mimic.md
+++ b/_potd_161_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_potd_161_enemies/mylodon.md
+++ b/_potd_161_enemies/mylodon.md
@@ -20,6 +20,7 @@ abilities:
     potency: 130
     description: 'instant circle AoE'
   - name: Snow Flurry
+    potency: ?
     description: 'telegraphed conal AoE'
 job_specifics:
   GNB:

--- a/_potd_161_enemies/mylodon.md
+++ b/_potd_161_enemies/mylodon.md
@@ -20,7 +20,6 @@ abilities:
     potency: 130
     description: 'instant circle AoE'
   - name: Snow Flurry
-    potency: ?
     description: 'telegraphed conal AoE'
 job_specifics:
   GNB:

--- a/_potd_161_enemies/tursus.md
+++ b/_potd_161_enemies/tursus.md
@@ -18,6 +18,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Chilling Cyclone
+    potency: 300
     description: 'telegraphed conal AoE; inflicts deep freeze (DoT potency 50,
     9s)'
   - name: Ice Dispenser

--- a/_potd_171_enemies/anzu.md
+++ b/_potd_171_enemies/anzu.md
@@ -21,7 +21,8 @@ abilities:
   - name: Flying Frenzy
     potency: 180
     description: 'instant circle AoE gap closer; inflicts stun (2s) and
-    vulnerability up (50%, 10s)'
+    vulnerability up (50%, 10s). Diminishing returns do NOT apply to this stun
+    (it is always 2s)'
 notes:
   - If in a party, spread out to minimize damage from Flying Frenzy
 job_specifics:

--- a/_potd_171_enemies/anzu.md
+++ b/_potd_171_enemies/anzu.md
@@ -17,6 +17,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: 'Sonic Boom (?)'
+    potency: n/a
     description: 'instant; inflicts windburn (DoT potency 15, 20s)'
   - name: Flying Frenzy
     potency: 180

--- a/_potd_171_enemies/bird.md
+++ b/_potd_171_enemies/bird.md
@@ -24,6 +24,7 @@ abilities:
     potency: 300
     description: 'telegraphed circle AoE; inflicts confused (10s)'
   - name: Tropical Wind
+    potency: n/a
     description: 'grants physical damage up (80%, 30s) and haste (30s) to self,
     and causes it to spam Revelation. Can be interrupted, but not recommended
     as its casting will give you lots of breathing room'

--- a/_potd_171_enemies/coeurl.md
+++ b/_potd_171_enemies/coeurl.md
@@ -17,6 +17,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Megablaster
+    potency: ?
     description: 'telegraphed conal AoE. Doesn''t use this while you''re
     paralyzed'
   - name: 'Blaster (?)'

--- a/_potd_171_enemies/coeurl.md
+++ b/_potd_171_enemies/coeurl.md
@@ -17,10 +17,10 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Megablaster
-    potency: ?
     description: 'telegraphed conal AoE. Doesn''t use this while you''re
     paralyzed'
   - name: 'Blaster (?)'
+    potency: n/a
     description: 'inflicts paralyze (30s)'
 notes:
   - 'If there are several, you may want to pull them in quick succession to

--- a/_potd_171_enemies/dhalmel.md
+++ b/_potd_171_enemies/dhalmel.md
@@ -20,6 +20,7 @@ abilities:
     potency: 300
     description: 'telegraphed conal AoE'
   - name: Whistle
+    potency: n/a
     description: 'grants physical damage up (50%, 15s) to self'
 job_specifics:
   GNB:

--- a/_potd_171_enemies/mimic.md
+++ b/_potd_171_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_potd_171_enemies/sasquatch.md
+++ b/_potd_171_enemies/sasquatch.md
@@ -21,7 +21,8 @@ abilities:
     description: 'instant'
   - name: Ripe Banana
     description: 'grants physical damage up (100%, 15s) to self and heals 20%
-    of max HP; only used out of combat'
+    of max HP; only used out of combat. After using this, it will use Chest
+    Thump every few seconds until the buff expires'
   - name: Chest Thump
     description: 'huge 1.5 room instant AoE that inflicts stacking physical
     vulnerability up (10% per stack, max 5 stacks, 8s). Only used out of combat

--- a/_potd_171_enemies/sasquatch.md
+++ b/_potd_171_enemies/sasquatch.md
@@ -20,10 +20,12 @@ abilities:
     potency: 200
     description: 'instant'
   - name: Ripe Banana
+    potency: n/a
     description: 'grants physical damage up (100%, 15s) to self and heals 20%
     of max HP; only used out of combat. After using this, it will use Chest
     Thump every few seconds until the buff expires'
   - name: Chest Thump
+    potency: n/a
     description: 'huge 1.5 room instant AoE that inflicts stacking physical
     vulnerability up (10% per stack, max 5 stacks, 8s). Only used out of combat
     during Ripe Banana'

--- a/_potd_171_enemies/wisent.md
+++ b/_potd_171_enemies/wisent.md
@@ -18,11 +18,11 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Khoomii
+    potency: n/a
     description: 'draws players in and inflicts an extreme heavy debuff (10s);
     used 30 seconds after pull; can use knockback immunity. Draw-in will not
     work under the Knockback Penalty enchantment'
   - name: Horroisonous Blast
-    potency: ?
     description: 'telegraphed pointblank AoE that causes damage and paralyze;
     used immediately after Khoomii, making it difficult to escape'
 job_specifics:

--- a/_potd_171_enemies/wisent.md
+++ b/_potd_171_enemies/wisent.md
@@ -22,6 +22,7 @@ abilities:
     used 30 seconds after pull; can use knockback immunity. Draw-in will not
     work under the Knockback Penalty enchantment'
   - name: Horroisonous Blast
+    potency: ?
     description: 'telegraphed pointblank AoE that causes damage and paralyze;
     used immediately after Khoomii, making it difficult to escape'
 job_specifics:

--- a/_potd_181_enemies/archaeosaur.md
+++ b/_potd_181_enemies/archaeosaur.md
@@ -20,7 +20,6 @@ abilities:
     potency: 130
     description: 'instant'
   - name: Primordial Bark
-    potency: ?
     description: 'telegraphed pointblank AoE'
 job_specifics:
   GNB:

--- a/_potd_181_enemies/archaeosaur.md
+++ b/_potd_181_enemies/archaeosaur.md
@@ -20,6 +20,7 @@ abilities:
     potency: 130
     description: 'instant'
   - name: Primordial Bark
+    potency: ?
     description: 'telegraphed pointblank AoE'
 job_specifics:
   GNB:

--- a/_potd_181_enemies/claw.md
+++ b/_potd_181_enemies/claw.md
@@ -24,7 +24,8 @@ abilities:
     potency: 130
     description: 'used against players with prey; clears prey status'
   - name: Tail Screw
-    description: 'attack that applies slow. Can be outrun'
+    potency: ?
+    description: 'inflicts slow; can be outranged'
 notes:
   - 'Does a draw-in that applies Prey status followed by Impale. Knockback
     immunity does not work, but draw-in will not work on floors with knockback

--- a/_potd_181_enemies/claw.md
+++ b/_potd_181_enemies/claw.md
@@ -18,13 +18,13 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: 'Inspire (?)'
+    potency: n/a
     description: 'instant; draws the target in and inflicts prey. Knockback
     immunity does not work against the draw-in'
   - name: Impale
     potency: 130
     description: 'used against players with prey; clears prey status'
   - name: Tail Screw
-    potency: ?
     description: 'inflicts slow; can be outranged'
 notes:
   - 'Does a draw-in that applies Prey status followed by Impale. Knockback

--- a/_potd_181_enemies/crawler.md
+++ b/_potd_181_enemies/crawler.md
@@ -6,6 +6,7 @@ start_floor: 183
 end_floor: 186
 agro: Sound
 hp: 27005
+attack_damage: 2552
 attack_type: Physical
 vulnerabilities:
   bind: true
@@ -16,9 +17,10 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: 'Sticky Thread'
-    description: 'instant conal AoE that applies slow'
-  - name: '?'
-    description: 'instant conal AoE that applies poison'
+    potency: 120
+    description: 'instant conal AoE; inflicts slow (30s)'
+  - name: 'Poison Breath (?)'
+    description: 'instant conal AoE; inflicts poison (DoT potency 60, 20s)'
 job_specifics:
   GNB:
     difficulty: Medium

--- a/_potd_181_enemies/crawler.md
+++ b/_potd_181_enemies/crawler.md
@@ -20,6 +20,7 @@ abilities:
     potency: 120
     description: 'instant conal AoE; inflicts slow (30s)'
   - name: 'Poison Breath (?)'
+    potency: n/a
     description: 'instant conal AoE; inflicts poison (DoT potency 60, 20s)'
 job_specifics:
   GNB:

--- a/_potd_181_enemies/dragon.md
+++ b/_potd_181_enemies/dragon.md
@@ -20,6 +20,7 @@ abilities:
     potency: 120
     description: 'instant circle AoE; inflicts frostbite (DoT potency 100, 21s)'
   - name: 'Granite Rain'
+    potency: ?
     description: telegraphed pointblank AoE
 job_specifics:
   GNB:

--- a/_potd_181_enemies/dragon.md
+++ b/_potd_181_enemies/dragon.md
@@ -20,7 +20,6 @@ abilities:
     potency: 120
     description: 'instant circle AoE; inflicts frostbite (DoT potency 100, 21s)'
   - name: 'Granite Rain'
-    potency: ?
     description: telegraphed pointblank AoE
 job_specifics:
   GNB:

--- a/_potd_181_enemies/garm.md
+++ b/_potd_181_enemies/garm.md
@@ -27,6 +27,9 @@ abilities:
     description: 'untelegraphed pointblank AoE - get OUT. Inflicts
     electrocution (DoT potency 50, 30s) and paralysis (30s). Can be
     interrupted'
+  - name: 'The Dragon''s Breath'
+    potency: 300?
+    description: 'telegraphed conal AoE'
   - name: 'The Lion''s Breath'
     potency: 300?
     description: 'telegraphed conal AoE'
@@ -34,7 +37,7 @@ abilities:
     potency: 300?
     description: 'telegraphed conal AoE'
 notes:
-  - 'These mostly just spam abilities, doing very little autoattack damage'
+  - 'These mostly just spam abilities, doing very little auto-attack damage'
   - 'Try to stand behind it during Voice and Breath attacks to delay its next
   auto-attack'
 job_specifics:
@@ -46,7 +49,7 @@ job_specifics:
     difficulty: Easy
     notes:
       - 'Try to always stay at a medium range, so it''s easy to move in or out
-        when necessary. A bit of range will help to avoid some autoattacks too'
+        when necessary. A bit of range will help to avoid some auto-attacks too'
       - 'Can interrupt a Voice if you need to, but save for emergencies
         (avoiding another patrol, etc.)'
   PLD:

--- a/_potd_181_enemies/grenade.md
+++ b/_potd_181_enemies/grenade.md
@@ -18,6 +18,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Hypothermal Combustion
+    potency: ?
     description: 'telegraphed pointblank AoE'
 job_specifics:
   GNB:

--- a/_potd_181_enemies/grenade.md
+++ b/_potd_181_enemies/grenade.md
@@ -18,7 +18,6 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Hypothermal Combustion
-    potency: ?
     description: 'telegraphed pointblank AoE'
 job_specifics:
   GNB:

--- a/_potd_181_enemies/mimic.md
+++ b/_potd_181_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_potd_181_enemies/vindthurs.md
+++ b/_potd_181_enemies/vindthurs.md
@@ -19,8 +19,10 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Freezeover
+    potency: ?
     description: 'telegraphed circle AoE'
   - name: Plain Pound
+    potency: ?
     description: 'telegraphed pointblank AoE'
 job_specifics:
   GNB:

--- a/_potd_181_enemies/vindthurs.md
+++ b/_potd_181_enemies/vindthurs.md
@@ -19,10 +19,8 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Freezeover
-    potency: ?
     description: 'telegraphed circle AoE'
   - name: Plain Pound
-    potency: ?
     description: 'telegraphed pointblank AoE'
 job_specifics:
   GNB:

--- a/_potd_181_enemies/wamoura.md
+++ b/_potd_181_enemies/wamoura.md
@@ -18,9 +18,9 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Poison Dust
-    potency: ?
     description: 'telegraphed conal AoE; inflicts poison'
   - name: Exuviation
+    potency: n/a
     description: 'heals another enemy. If you pull multiple mobs, kill the
     Wamoura first. If you pull 2 Wamouras, you''ll probably have to use
     Witching or Rage to avoid them healing each other forever'

--- a/_potd_181_enemies/wamoura.md
+++ b/_potd_181_enemies/wamoura.md
@@ -18,7 +18,8 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Poison Dust
-    description: 'telegraphed conal AoE'
+    potency: ?
+    description: 'telegraphed conal AoE; inflicts poison'
   - name: Exuviation
     description: 'heals another enemy. If you pull multiple mobs, kill the
     Wamoura first. If you pull 2 Wamouras, you''ll probably have to use

--- a/_potd_191_enemies/bicephalus.md
+++ b/_potd_191_enemies/bicephalus.md
@@ -21,6 +21,7 @@ abilities:
     potency: 150
     description: 'instant'
   - name: Catapult
+    potency: ?
     description: 'telegraphed circle AoE'
 job_specifics:
   GNB:

--- a/_potd_191_enemies/bicephalus.md
+++ b/_potd_191_enemies/bicephalus.md
@@ -21,7 +21,6 @@ abilities:
     potency: 150
     description: 'instant'
   - name: Catapult
-    potency: ?
     description: 'telegraphed circle AoE'
 job_specifics:
   GNB:

--- a/_potd_191_enemies/dragon.md
+++ b/_potd_191_enemies/dragon.md
@@ -17,6 +17,7 @@ vulnerabilities:
   resolution: true
 abilities:
   - name: Evil Eye
+    potency: n/a
     description: conal gaze AoE - look away, get behind, or get away
   - name: Miasma Breath
     potency: 300

--- a/_potd_191_enemies/fachan.md
+++ b/_potd_191_enemies/fachan.md
@@ -20,6 +20,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Level 5 Death
+    potency: n/a
     description: 'untelegraphed conal gaze AoE causing instant death - look
     away, get behind, or get away'
 notes:

--- a/_potd_191_enemies/knight.md
+++ b/_potd_191_enemies/knight.md
@@ -20,6 +20,7 @@ abilities:
     potency: 130
     description: 'instant'
   - name: Death Spiral
+    potency: ?
     description: scary-looking telegraphed donut AoE
   - name: Ossify
     description: 'grants physical damage up (100%, 8s) to self'

--- a/_potd_191_enemies/knight.md
+++ b/_potd_191_enemies/knight.md
@@ -20,11 +20,12 @@ abilities:
     potency: 130
     description: 'instant'
   - name: Death Spiral
-    potency: ?
     description: scary-looking telegraphed donut AoE
   - name: Ossify
+    potency: n/a
     description: 'grants physical damage up (100%, 8s) to self'
   - name: '?'
+    potency: n/a
     description: 'grants physical vulnerability down (20s) to self'
 notes:
   - 'Do not fight one of these with a Wraith nearby, as the Wraith can cast

--- a/_potd_191_enemies/mimic.md
+++ b/_potd_191_enemies/mimic.md
@@ -18,6 +18,7 @@ vulnerabilities:
 gallery_only: true
 abilities:
   - name: Infatuation
+    potency: n/a
     description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300

--- a/_potd_floorsets/011.md
+++ b/_potd_floorsets/011.md
@@ -18,9 +18,11 @@ boss_abilities:
     potency: 300
     description: 'instant'
   - name: Acid Mist
+    potency: n/a
     description: 'telegraphed pointblank AoE; inflicts poison (DoT potency 75,
     30s)'
   - name: Gold Dust
+    potency: n/a
     description: 'telegraphed circle AoE; inflicts poison (DoT potency 75,
     30s)'
   - name: Leafstorm

--- a/_potd_floorsets/021.md
+++ b/_potd_floorsets/021.md
@@ -25,6 +25,7 @@ boss_abilities:
     potency: 50
     description: 'instant circle AoE on random player; leaves heavy puddle'
   - name: Fear Itself
+    potency: n/a
     description: 'roomwide donut AoE; inflicts hysteria (10s); must be
     inside/near boss''s target circle to avoid'
 boss_notes:

--- a/_potd_floorsets/041.md
+++ b/_potd_floorsets/041.md
@@ -29,6 +29,7 @@ boss_abilities:
     description: 'roomwide AoE; adds 960 damage (Steel-piercing) for each
     player who was hit by In Health'
   - name: Cold Feet
+    potency: n/a
     description: '360 degree gaze AoE; inflicts confused (10s)'
 boss_notes:
   - note: 'Initial rotation:'

--- a/_potd_floorsets/091.md
+++ b/_potd_floorsets/091.md
@@ -26,9 +26,11 @@ boss_abilities:
     potency: 110
     description: 'instant roomwide(?) AoE'
   - name: Doom
+    potency: n/a
     description: 'telegraphed huge conal AoE; inflicts doom (20s). Doom can be
     removed with Esuna'
   - name: Summon Darkness
+    potency: n/a
     description: 'phase change action; summons corse adds'
 boss_notes:
   - note: 'Timeline:'

--- a/_potd_floorsets/111.md
+++ b/_potd_floorsets/111.md
@@ -19,9 +19,11 @@ boss_abilities:
     potency: 150
     description: 'instant'
   - name: Acid Mist
+    potency: n/a
     description: 'telegraphed pointblank AoE; inflicts poison (DoT potency 150,
     30s)'
   - name: Gold Dust
+    potency: n/a
     description: 'telegraphed circle AoE; inflicts poison (DoT potency 150,
     30s)'
   - name: Leafstorm

--- a/_potd_floorsets/141.md
+++ b/_potd_floorsets/141.md
@@ -25,10 +25,13 @@ boss_abilities:
     potency: 350?
     description: 'telegraphed wide line AoE'
   - name: Summon Darkness
+    potency: n/a
     description: 'summons one of four types of adds (see rotation)'
   - name: Fatal Allure
+    potency: n/a
     description: 'draws succubus add to boss and inflicts terror on it'
   - name: Blood Sword
+    potency: n/a
     description: 'kills succubus add, absorbing its remaining HP'
   - name: Blood Rain
     potency: 350


### PR DESCRIPTION
Here you go! I managed to work out autoattack damage for most enemies; a lot of HP values still use the rounded-to-1000 values from Cloudburst's spreadsheet, but I found the level 70 enemy HP multiplier for EW (223.92) so I should be able to work out exact values next time I go in to collect data.
I also tweaked a couple of PotD entries (see changelog) and added "?" potency entries for abilities I don't have damage for (mostly AoEs which everybody avoids), and I cleaned up a bit of inconsistency in wording/spelling: "inflicts" for debuffs and "grants" for buffs (not "applies" or "causes"), "auto-attack" instead of "autoattack" (official text seems to use the hyphenated wording), "pull" instead of "pull/aggro" (on enrage timing), "untelegraphed" instead of "non-telegraphed", "LoSed" instead of "LoS'd" (mainly personal preference on this last, but the former is how I wrote it for PotD enemies).