### PR TITLE
Add damage types for PotD enemy abilities

### DIFF
--- a/_data/changelog.yml
+++ b/_data/changelog.yml
@@ -2,7 +2,7 @@
   updates:
     - 'Added damage types for PotD enemy abilities, courtesy of vaxherd'
     - 'Fixed missing damage for Deep Palace Ochu and Abaia AoE abilities'
-    - 'Fixed description of Kirtimukha's Rotten Stench (not a guaranteed
+    - 'Fixed description of Kirtimukha''s Rotten Stench (not a guaranteed
     one-shot)'
 - date: 2023-01-18
   updates:

--- a/_data/changelog.yml
+++ b/_data/changelog.yml
@@ -1,3 +1,9 @@
+- date: 2023-01-19
+  updates:
+    - 'Added damage types for PotD enemy abilities, courtesy of vaxherd'
+    - 'Fixed missing damage for Deep Palace Ochu and Abaia AoE abilities'
+    - 'Fixed description of Kirtimukha's Rotten Stench (not a guaranteed
+    one-shot)'
 - date: 2023-01-18
   updates:
     - 'Added icons for physical/magic/unique damage types - currently visible

--- a/_hoh_001_enemies/mimic.md
+++ b/_hoh_001_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Malice
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in bronze chests'

--- a/_hoh_011_enemies/mimic.md
+++ b/_hoh_011_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Malice
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in bronze chests'

--- a/_hoh_021_enemies/mimic.md
+++ b/_hoh_021_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Malice
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in bronze chests'

--- a/_hoh_031_enemies/mimic.md
+++ b/_hoh_031_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Malice
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in silver chests'

--- a/_hoh_041_enemies/mimic.md
+++ b/_hoh_041_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Malice
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in silver chests'

--- a/_hoh_051_enemies/mimic.md
+++ b/_hoh_051_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Malice
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in silver chests'

--- a/_hoh_061_enemies/mimic.md
+++ b/_hoh_061_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Malice
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_hoh_071_enemies/mimic.md
+++ b/_hoh_071_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Malice
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_hoh_081_enemies/mimic.md
+++ b/_hoh_081_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Malice
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_hoh_091_enemies/mimic.md
+++ b/_hoh_091_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Malice
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_001_enemies/bat.md
+++ b/_potd_001_enemies/bat.md
@@ -17,6 +17,7 @@ vulnerabilities:
 abilities:
   - name: Blood Drain
     potency: 100
+    type: Unique
     description: 'pierces Steel; absorbs 50% of damage dealt'
   - name: Ultrasonics
     potency: n/a

--- a/_potd_001_enemies/beetle.md
+++ b/_potd_001_enemies/beetle.md
@@ -17,7 +17,7 @@ vulnerabilities:
 abilities:
   - name: Spoil
     potency: n/a
-    description: 'inflicts poison (DoT potency 20, 15s)'
+    description: 'inflicts poison (unique DoT potency 20, 15s)'
 job_specifics:
   SGE:
     difficulty: Easy

--- a/_potd_001_enemies/coblyn.md
+++ b/_potd_001_enemies/coblyn.md
@@ -17,6 +17,7 @@ vulnerabilities:
 abilities:
   - name: Shatter
     potency: 300
+    type: Magic
     description: 'telegraphed pointblank AoE'
 job_specifics:
   SGE:

--- a/_potd_001_enemies/dung_beetle.md
+++ b/_potd_001_enemies/dung_beetle.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Rhino Attack
     potency: 250
+    type: Physical
     description: 'gap closer (can be LoSed)'
 job_specifics:
   SGE:

--- a/_potd_001_enemies/goblin.md
+++ b/_potd_001_enemies/goblin.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Bomb Toss
     potency: 200
+    type: Magic
     description: 'either a telegraphed circle AoE, or an untelegraphed
     pointblank AoE which also damages the goblin itself'
 job_specifics:

--- a/_potd_001_enemies/hippocerf.md
+++ b/_potd_001_enemies/hippocerf.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Shriek
     potency: 200
+    type: Magic
     description: 'telegraphed pointblank AoE; inflicts stun (6s)'
 job_specifics:
   SGE:

--- a/_potd_001_enemies/hornet.md
+++ b/_potd_001_enemies/hornet.md
@@ -17,6 +17,7 @@ vulnerabilities:
 abilities:
   - name: Final Sting
     potency: 70% of max HP
+    type: Unique
     description: 'sacrifial enrage; possible to outrange. Used every 22
     seconds'
 job_specifics:

--- a/_potd_001_enemies/mimic.md
+++ b/_potd_001_enemies/mimic.md
@@ -18,9 +18,10 @@ gallery_only: true
 abilities:
   - name: Infatuation
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in bronze chests'

--- a/_potd_011_enemies/biloko.md
+++ b/_potd_011_enemies/biloko.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: The Wood Remembers
     potency: 300
+    type: Physical
     description: 'telegraphed conal AoE'
 job_specifics:
   SGE:

--- a/_potd_011_enemies/cobra.md
+++ b/_potd_011_enemies/cobra.md
@@ -21,6 +21,7 @@ abilities:
     description: '360 degree gaze inflicting petrify (15s) - look away'
   - name: Devour
     potency: 100% of max HP
+    type: Unique
     description: 'instant death; only used if you are a toad'
 job_specifics:
   SGE:

--- a/_potd_011_enemies/mimic.md
+++ b/_potd_011_enemies/mimic.md
@@ -18,9 +18,10 @@ gallery_only: true
 abilities:
   - name: Infatuation
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in bronze chests'

--- a/_potd_011_enemies/morbol.md
+++ b/_potd_011_enemies/morbol.md
@@ -21,7 +21,7 @@ abilities:
 notes:
   - note: 'Bad Breath inflicts these debuffs:'
     subnotes:
-      - 'Poison (DoT potency 50, 30s)'
+      - 'Poison (unique DoT potency 50, 30s)'
       - 'Nausea (20s)'
       - 'Slow (10s)'
       - 'Blind (30s)'

--- a/_potd_011_enemies/ninki_nanka.md
+++ b/_potd_011_enemies/ninki_nanka.md
@@ -17,6 +17,7 @@ vulnerabilities:
 abilities:
   - name: Brackish Drop
     potency: 650
+    type: Magic
     description: 'telegraphed circle AoE'
 job_specifics:
   SGE:

--- a/_potd_011_enemies/seedling.md
+++ b/_potd_011_enemies/seedling.md
@@ -15,8 +15,8 @@ vulnerabilities:
   slow: true
   stun: true
 notes:
-  - 'Autoattack inflicts stacking poison (DoT potency 10 per stack, max 4
-    stacks, 9s)'
+  - 'Autoattack inflicts stacking poison (physical DoT potency 10 per stack,
+    max 4 stacks, 9s)'
 job_specifics:
   SGE:
     difficulty: Easy

--- a/_potd_011_enemies/slime.md
+++ b/_potd_011_enemies/slime.md
@@ -17,9 +17,11 @@ vulnerabilities:
 abilities:
   - name: Digest
     potency: 100
+    type: Physical
     description: 'absorbs 100% of damage dealt'
   - name: Rapture
     potency: 170% of max HP
+    type: Unique
     description: 'instant AoE sacrificial enrage; used 20 seconds after pull
     (immediately after the second Digest)'
 job_specifics:

--- a/_potd_011_enemies/toad.md
+++ b/_potd_011_enemies/toad.md
@@ -17,9 +17,11 @@ vulnerabilities:
 abilities:
   - name: Sticky Tongue
     potency: 50
+    type: Physical
     description: 'instant; draws the target in'
   - name: Labored Leap
     potency: 500
+    type: Physical
     description: 'telegraphed pointblank AoE; used immediately after Sticky
     Tongue'
 job_specifics:

--- a/_potd_011_enemies/uragnite.md
+++ b/_potd_011_enemies/uragnite.md
@@ -17,7 +17,7 @@ vulnerabilities:
 abilities:
   - name: 'Gas Shell'
     potency: n/a
-    description: 'inflicts poison (DoT potency 30, 12s)'
+    description: 'inflicts poison (unique DoT potency 30, 12s)'
 job_specifics:
   SGE:
     difficulty: Easy

--- a/_potd_011_enemies/whelk.md
+++ b/_potd_011_enemies/whelk.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Suction
     potency: 130
+    type: Physical
     description: 'instant'
 job_specifics:
   SGE:

--- a/_potd_021_enemies/adamantoise.md
+++ b/_potd_021_enemies/adamantoise.md
@@ -17,6 +17,7 @@ vulnerabilities:
 abilities:
   - name: Tortoise Stomp
     potency: 500
+    type: Physical
     description: 'large telegraphed pointblank AoE'
 job_specifics:
   SGE:

--- a/_potd_021_enemies/centaur.md
+++ b/_potd_021_enemies/centaur.md
@@ -20,6 +20,7 @@ abilities:
     description: 'grants physical damage up (50%, 20s) to self'
   - name: Rear
     potency: 300
+    type: Magic
     description: 'telegraphed pointblank AoE'
 job_specifics:
   SGE:

--- a/_potd_021_enemies/drake.md
+++ b/_potd_021_enemies/drake.md
@@ -17,7 +17,7 @@ vulnerabilities:
 abilities:
   - name: Smoldering Scales
     potency: n/a
-    description: 'grants counterattack (potency 200, 5s) to self'
+    description: 'grants counterattack (magic potency 200, 5s) to self'
 job_specifics:
   SGE:
     difficulty: Easy

--- a/_potd_021_enemies/dullahan.md
+++ b/_potd_021_enemies/dullahan.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Iron Justice
     potency: 300
+    type: Physical
     description: 'telegraphed conal AoE'
 job_specifics:
   SGE:

--- a/_potd_021_enemies/effigy.md
+++ b/_potd_021_enemies/effigy.md
@@ -17,6 +17,7 @@ vulnerabilities:
 abilities:
   - name: Wild Horn
     potency: 200
+    type: Physical
     description: 'large telegraphed conal AoE; inflicts knockback'
 job_specifics:
   SGE:

--- a/_potd_021_enemies/marolith.md
+++ b/_potd_021_enemies/marolith.md
@@ -17,6 +17,7 @@ vulnerabilities:
 abilities:
   - name: Dark Blizzard III
     potency: 200
+    type: Magic
     description: 'telegraphed circle AoE'
 job_specifics:
   SGE:

--- a/_potd_021_enemies/mimic.md
+++ b/_potd_021_enemies/mimic.md
@@ -18,9 +18,10 @@ gallery_only: true
 abilities:
   - name: Infatuation
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in bronze chests'

--- a/_potd_021_enemies/minotaur.md
+++ b/_potd_021_enemies/minotaur.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: '111-tonze Swing'
     potency: 600
+    type: Physical
     description: 'untelegraphed pointblank AoE; inflicts knockback. Fully
     shielding the damage does NOT block the knockback'
 job_specifics:

--- a/_potd_021_enemies/puk.md
+++ b/_potd_021_enemies/puk.md
@@ -17,6 +17,7 @@ vulnerabilities:
 abilities:
   - name: Fireball
     potency: 300
+    type: Magic
     description: 'telegraphed circle AoE'
 job_specifics:
   SGE:

--- a/_potd_021_enemies/wivre.md
+++ b/_potd_021_enemies/wivre.md
@@ -17,6 +17,7 @@ vulnerabilities:
 abilities:
   - name: Horrid Horn
     potency: 130
+    type: Physical
     description: 'instant'
 job_specifics:
   SGE:

--- a/_potd_031_enemies/bogy.md
+++ b/_potd_031_enemies/bogy.md
@@ -17,6 +17,7 @@ vulnerabilities:
 abilities:
   - name: Curse
     potency: 200
+    type: Magic
     description: 'telegraphed pointblank AoE; also deals 500 MP damage'
 job_specifics:
   SGE:

--- a/_potd_031_enemies/dahak.md
+++ b/_potd_031_enemies/dahak.md
@@ -17,8 +17,9 @@ vulnerabilities:
 abilities:
   - name: 'Tail Drive (?)'
     potency: 300
-    description: 'telegraphed backward conal AoE inflicting concussion (DoT
-    potency 30, 30s); used if someone is behind'
+    type: Physical
+    description: 'telegraphed backward conal AoE inflicting concussion
+    (physical DoT potency 30, 30s); used if someone is behind'
 job_specifics:
   SGE:
     difficulty: Easy

--- a/_potd_031_enemies/eye.md
+++ b/_potd_031_enemies/eye.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Eyes on Me
     potency: 150
+    type: Magic
     description: 'untelegraphed pointblank AoE'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'

--- a/_potd_031_enemies/gourmand.md
+++ b/_potd_031_enemies/gourmand.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Beatdown
     potency: 130
+    type: Physical
     description: 'instant'
 job_specifics:
   SGE:

--- a/_potd_031_enemies/haagenti.md
+++ b/_potd_031_enemies/haagenti.md
@@ -17,6 +17,7 @@ vulnerabilities:
 abilities:
   - name: Triclip
     potency: 120
+    type: Physical
     description: 'instant'
 job_specifics:
   SGE:

--- a/_potd_031_enemies/hecteyes.md
+++ b/_potd_031_enemies/hecteyes.md
@@ -17,6 +17,7 @@ vulnerabilities:
 abilities:
   - name: Hex Eye
     potency: 200
+    type: Magic
     description: 'telegraphed pointblank AoE; inflicts paralysis (15s)'
 job_specifics:
   SGE:

--- a/_potd_031_enemies/mimic.md
+++ b/_potd_031_enemies/mimic.md
@@ -18,9 +18,10 @@ gallery_only: true
 abilities:
   - name: Infatuation
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in silver chests'

--- a/_potd_031_enemies/monk.md
+++ b/_potd_031_enemies/monk.md
@@ -22,6 +22,7 @@ abilities:
     description: 'large untelegraphed pointblank AoE; draws players in'
   - name: Flood
     potency: 250
+    type: Magic
     description: 'telegraphed pointblank AoE; used immediately after Sucker'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'

--- a/_potd_031_enemies/mummy.md
+++ b/_potd_031_enemies/mummy.md
@@ -17,6 +17,7 @@ vulnerabilities:
 abilities:
   - name: Rotting Bandages
     potency: 130
+    type: Physical
     description: 'telegraphed conal AoE; inflicts stun (6s)'
 job_specifics:
   SGE:

--- a/_potd_031_enemies/ogre.md
+++ b/_potd_031_enemies/ogre.md
@@ -17,6 +17,7 @@ vulnerabilities:
 abilities:
   - name: Heartburn
     potency: 300
+    type: Magic
     description: 'large telegraphed circle AoE'
 job_specifics:
   SGE:

--- a/_potd_031_enemies/succubus.md
+++ b/_potd_031_enemies/succubus.md
@@ -18,9 +18,11 @@ vulnerabilities:
 abilities:
   - name: Dark Mist
     potency: 300
+    type: Magic
     description: 'large telegraphed pointblank AoE; inflicts terror (10s)'
   - name: Void Fire II
     potency: 300
+    type: Magic
     description: 'telegraphed circle AoE; used immediately after Dark Mist'
 job_specifics:
   SGE:

--- a/_potd_041_enemies/bloodguard.md
+++ b/_potd_041_enemies/bloodguard.md
@@ -17,9 +17,11 @@ vulnerabilities:
 abilities:
   - name: Void Slash
     potency: 100
+    type: Physical
     description: 'instant'
   - name: Void Trap
     potency: 300
+    type: Magic
     description: 'telegraphed circle AoE'
 job_specifics:
   SGE:

--- a/_potd_041_enemies/demon.md
+++ b/_potd_041_enemies/demon.md
@@ -17,6 +17,7 @@ vulnerabilities:
 abilities:
   - name: Dark Dome
     potency: 90
+    type: Magic
     description: 'instant'
 job_specifics:
   SGE:

--- a/_potd_041_enemies/dragon.md
+++ b/_potd_041_enemies/dragon.md
@@ -17,6 +17,7 @@ vulnerabilities:
 abilities:
   - name: Dark Thorn
     potency: 90
+    type: Magic
     description: 'telegraphed circle AoE'
 job_specifics:
   SGE:

--- a/_potd_041_enemies/gargoyle.md
+++ b/_potd_041_enemies/gargoyle.md
@@ -17,6 +17,7 @@ vulnerabilities:
 abilities:
   - name: Grim Reaper
     potency: 90
+    type: Magic
     description: 'instant'
 job_specifics:
   SGE:

--- a/_potd_041_enemies/gnat.md
+++ b/_potd_041_enemies/gnat.md
@@ -17,6 +17,7 @@ vulnerabilities:
 abilities:
   - name: Thunderstrike
     potency: 300
+    type: Magic
     description: 'telegraphed line AoE'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'

--- a/_potd_041_enemies/gravekeeper.md
+++ b/_potd_041_enemies/gravekeeper.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Nail in the Coffin
     potency: 150
+    type: Physical
     description: 'instant'
 job_specifics:
   SGE:

--- a/_potd_041_enemies/hellhound.md
+++ b/_potd_041_enemies/hellhound.md
@@ -17,6 +17,7 @@ vulnerabilities:
 abilities:
   - name: Ravenous Bite
     potency: 110
+    type: Physical
     description: 'instant'
 job_specifics:
   SGE:

--- a/_potd_041_enemies/manticore.md
+++ b/_potd_041_enemies/manticore.md
@@ -18,9 +18,11 @@ vulnerabilities:
 abilities:
   - name: Ripper Claw
     potency: 300
+    type: Physical
     description: 'untelegraphed conal AoE - don''t stand in front!'
   - name: Fireball
     potency: 300
+    type: Magic
     description: 'telegraphed circle AoE'
 job_specifics:
   SGE:

--- a/_potd_041_enemies/mimic.md
+++ b/_potd_041_enemies/mimic.md
@@ -18,9 +18,10 @@ gallery_only: true
 abilities:
   - name: Infatuation
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_041_enemies/wraith.md
+++ b/_potd_041_enemies/wraith.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Scream
     potency: 200
+    type: Magic
     description: 'huge telegraphed pointblank AoE; inflicts terror (15s); can
     be interrupted'
 job_specifics:

--- a/_potd_051_enemies/anubys.md
+++ b/_potd_051_enemies/anubys.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Spellsword
     potency: 300
+    type: Physical
     description: 'telegraphed conal AoE'
 job_specifics:
   SGE:

--- a/_potd_051_enemies/arch_demon.md
+++ b/_potd_051_enemies/arch_demon.md
@@ -19,9 +19,11 @@ vulnerabilities:
 abilities:
   - name: Abyssal Transfixion
     potency: 130
+    type: Physical
     description: 'instant'
   - name: Abyssal Swing
     potency: 300
+    type: Physical
     description: 'telegraphed conal AoE'
 job_specifics:
   SGE:

--- a/_potd_051_enemies/deepeye.md
+++ b/_potd_051_enemies/deepeye.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Optical Intrusion
     potency: 130
+    type: Physical
     description: 'instant'
   - name: Hypnotize
     potency: n/a

--- a/_potd_051_enemies/gremlin.md
+++ b/_potd_051_enemies/gremlin.md
@@ -21,6 +21,7 @@ abilities:
     description: 'instant; inflicts vulnerability up (25%, 10s)'
   - name: Fire II
     potency: 300
+    type: Magic
     description: 'telegraphed circle AoE'
 job_specifics:
   SGE:

--- a/_potd_051_enemies/idol.md
+++ b/_potd_051_enemies/idol.md
@@ -19,9 +19,11 @@ vulnerabilities:
 abilities:
   - name: Carpomission
     potency: 130
+    type: Physical
     description: 'instant'
   - name: Neck Splinter
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 job_specifics:
   SGE:

--- a/_potd_051_enemies/imp.md
+++ b/_potd_051_enemies/imp.md
@@ -19,7 +19,7 @@ vulnerabilities:
 abilities:
   - name: Ice Spikes
     potency: n/a
-    description: 'grants counterattack (potency 200, 5s) to self; can be
+    description: 'grants counterattack (magic potency 200, 5s) to self; can be
     interrupted'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'

--- a/_potd_051_enemies/mimic.md
+++ b/_potd_051_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Infatuation
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_051_enemies/pot.md
+++ b/_potd_051_enemies/pot.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Mysterious Light
     potency: 450
+    type: Magic
     description: 'roomwide gaze attack inflicting blind (15s) - look away'
 job_specifics:
   SGE:

--- a/_potd_051_enemies/soulflayer.md
+++ b/_potd_051_enemies/soulflayer.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Mind Blast
     potency: 300
+    type: Magic
     description: 'telegraphed pointblank AoE; inflicts paralysis (15s)'
   - name: 'Canker'
     potency: n/a

--- a/_potd_051_enemies/taurus.md
+++ b/_potd_051_enemies/taurus.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Frightful Roar
     potency: 300
+    type: Magic
     description: 'telegraphed pointblank AoE; inflicts vulnerability up (20%,
     30s)'
 job_specifics:

--- a/_potd_051_enemies/vodoriga.md
+++ b/_potd_051_enemies/vodoriga.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Terror Eye
     potency: 300
+    type: Magic
     description: 'telegraphed circle AoE; can be interrupted'
 job_specifics:
   SGE:

--- a/_potd_061_enemies/blade.md
+++ b/_potd_061_enemies/blade.md
@@ -19,9 +19,11 @@ vulnerabilities:
 abilities:
   - name: Third Leg Forward
     potency: 300
+    type: Physical
     description: 'telegraphed conal AoE'
   - name: Third Leg Back
     potency: 300
+    type: Physical
     description: 'telegraphed backward conal AoE; inflicts knockback; used
     after Third Leg Forward if someone is behind'
 job_specifics:

--- a/_potd_061_enemies/croc.md
+++ b/_potd_061_enemies/croc.md
@@ -18,9 +18,11 @@ vulnerabilities:
 abilities:
   - name: Flatten
     potency: 300
+    type: Physical
     description: 'telegraphed conal AoE'
   - name: 'Caudal Swipe'
     potency: 300
+    type: Physical
     description: 'telegraphed backward conal AoE inflicting stun (3s) and
     knockback; used if someone is behind'
 job_specifics:

--- a/_potd_061_enemies/elbst.md
+++ b/_potd_061_enemies/elbst.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Acid Shower
     potency: 130
+    type: Magic
     description: 'instant; inflicts vulnerability up (30%, 10s)'
 job_specifics:
   SGE:

--- a/_potd_061_enemies/mimic.md
+++ b/_potd_061_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Infatuation
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_061_enemies/mylodon.md
+++ b/_potd_061_enemies/mylodon.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Slowball
     potency: 300
+    type: Magic
     description: 'telegraphed circle AoE'
 job_specifics:
   SGE:

--- a/_potd_061_enemies/pteranodon.md
+++ b/_potd_061_enemies/pteranodon.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Lightning Bolt
     potency: 300
+    type: Magic
     description: 'telegraphed circle AoE'
 job_specifics:
   SGE:

--- a/_potd_061_enemies/raptor.md
+++ b/_potd_061_enemies/raptor.md
@@ -18,7 +18,9 @@ vulnerabilities:
 abilities:
   - name: Foul Breath
     potency: 300
-    description: 'telegraphed conal AoE; inflicts burns (DoT potency 30, 12s)'
+    type: Unique
+    description: 'telegraphed conal AoE; inflicts burns (unique DoT potency
+    30, 12s)'
 job_specifics:
   SGE:
     difficulty: Easy

--- a/_potd_061_enemies/sarcosuchus.md
+++ b/_potd_061_enemies/sarcosuchus.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Critical Bite
     potency: 300
+    type: Physical
     description: 'telegraphed conal AoE'
 job_specifics:
   SGE:

--- a/_potd_061_enemies/triceratops.md
+++ b/_potd_061_enemies/triceratops.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Batterhorn
     potency: 130
+    type: Physical
     description: 'instant'
 job_specifics:
   SGE:

--- a/_potd_061_enemies/tyrannosaur.md
+++ b/_potd_061_enemies/tyrannosaur.md
@@ -18,9 +18,11 @@ vulnerabilities:
 abilities:
   - name: Underbite
     potency: 130
+    type: Physical
     description: 'instant'
   - name: Primordial Roar
     potency: 300
+    type: Magic
     description: 'telegraphed pointblank AoE; inflicts stun (4s)'
 job_specifics:
   SGE:

--- a/_potd_061_enemies/wivre.md
+++ b/_potd_061_enemies/wivre.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Horrid Horn
     potency: 130
+    type: Physical
     description: 'instant'
 job_specifics:
   SGE:

--- a/_potd_071_enemies/anzu.md
+++ b/_potd_071_enemies/anzu.md
@@ -19,9 +19,10 @@ vulnerabilities:
 abilities:
   - name: 'Sonic Boom'
     potency: n/a
-    description: 'instant; inflicts windburn (DoT potency 30, 20s)'
+    description: 'instant; inflicts windburn (physical DoT potency 30, 20s)'
   - name: Flying Frenzy
     potency: 180
+    type: Physical
     description: 'instant circle AoE gap closer; inflicts stun (2s) and
     vulnerability up (50%, 10s); used when HP is below 30%. Diminishing returns
     do NOT apply to this stun (it is always 2s)'

--- a/_potd_071_enemies/aurochs.md
+++ b/_potd_071_enemies/aurochs.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Seismic Rift
     potency: 300
+    type: Magic
     description: 'telegraphed pointblank AoE'
 job_specifics:
   SGE:

--- a/_potd_071_enemies/bandersnatch.md
+++ b/_potd_071_enemies/bandersnatch.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Catching Claws
     potency: 130
+    type: Physical
     description: 'instant'
 job_specifics:
   SGE:

--- a/_potd_071_enemies/bear.md
+++ b/_potd_071_enemies/bear.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Savage Swipe
     potency: 300
+    type: Physical
     description: 'telegraphed conal AoE'
 job_specifics:
   SGE:

--- a/_potd_071_enemies/bird.md
+++ b/_potd_071_enemies/bird.md
@@ -19,9 +19,11 @@ vulnerabilities:
 abilities:
   - name: Filoplumes
     potency: 130
+    type: Physical
     description: 'instant'
   - name: Revelation
     potency: 300
+    type: Physical
     description: 'telegraphed circle AoE; inflicts confused (10s)'
 job_specifics:
   SGE:

--- a/_potd_071_enemies/coeurl.md
+++ b/_potd_071_enemies/coeurl.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Megablaster
     potency: 300
+    type: Magic
     description: 'telegraphed conal AoE; inflicts paralysis (15s)'
 job_specifics:
   SGE:

--- a/_potd_071_enemies/cyclops.md
+++ b/_potd_071_enemies/cyclops.md
@@ -19,10 +19,12 @@ vulnerabilities:
 abilities:
   - name: Eye of the Beholder
     potency: 300
+    type: Magic
     description: 'huge untelegraphed 270 degree donut AoE inflicting
-    electrocution (DoT potency 30, 12s) - get in or get behind'
+    electrocution (magic DoT potency 30, 12s) - get in or get behind'
   - name: 100-tonze Swing
     potency: 600
+    type: Physical
     description: 'untelegraphed pointblank AoE; inflicts knockback'
 job_specifics:
   SGE:

--- a/_potd_071_enemies/dhalmel.md
+++ b/_potd_071_enemies/dhalmel.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Whiplash
     potency: 300
+    type: Physical
     description: 'telegraphed conal AoE'
   - name: Whistle
     potency: n/a

--- a/_potd_071_enemies/lion.md
+++ b/_potd_071_enemies/lion.md
@@ -17,9 +17,11 @@ vulnerabilities:
 abilities:
   - name: Pounce
     potency: 130
+    type: Physical
     description: 'instant'
   - name: Cry
     potency: 300
+    type: Magic
     description: 'large telegraphed pointblank AoE'
 job_specifics:
   SGE:

--- a/_potd_071_enemies/mimic.md
+++ b/_potd_071_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Infatuation
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_071_enemies/sasquatch.md
+++ b/_potd_071_enemies/sasquatch.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Stool Pelt
     potency: 300
+    type: Physical
     description: 'telegraphed circle AoE'
   - name: Ripe Banana
     potency: n/a

--- a/_potd_071_enemies/wolf.md
+++ b/_potd_071_enemies/wolf.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Sanguine Bite
     potency: 130
+    type: Physical
     description: 'instant; absorbs 100% of damage dealt'
 job_specifics:
   SGE:

--- a/_potd_081_enemies/bomb.md
+++ b/_potd_081_enemies/bomb.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: 'Self-destruct'
     potency: 70% of max HP
+    type: Unique
     description: 'instant AoE sacrifical enrage; used 37 seconds after pull'
 job_specifics:
   SGE:

--- a/_potd_081_enemies/chimera.md
+++ b/_potd_081_enemies/chimera.md
@@ -19,12 +19,16 @@ vulnerabilities:
 abilities:
   - name: 'The Dragon''s Breath'
     potency: 300
+    type: Unique
     description: 'telegraphed conal AoE; inflicts paralysis (15s)'
   - name: 'The Lion''s Breath'
     potency: 300
-    description: 'telegraphed conal AoE; inflicts burns (DoT potency 50, 21s)'
+    type: Unique
+    description: 'telegraphed conal AoE; inflicts burns (unique DoT potency
+    50, 21s)'
   - name: 'The Ram''s Breath'
     potency: 300
+    type: Unique
     description: 'telegraphed conal AoE; inflicts heavy (10s)'
 notes:
   - 'Can appear on any floor from 81-89, but seems fairly rare in the earlier

--- a/_potd_081_enemies/claw.md
+++ b/_potd_081_enemies/claw.md
@@ -23,6 +23,7 @@ abilities:
     immunity does not work against the draw-in'
   - name: Impale
     potency: 130
+    type: Physical
     description: 'used against players with prey; clears prey status'
 job_specifics:
   SGE:

--- a/_potd_081_enemies/dragon.md
+++ b/_potd_081_enemies/dragon.md
@@ -18,8 +18,9 @@ vulnerabilities:
 abilities:
   - name: Fireball
     potency: 300
-    description: 'telegraphed circle AoE; inflicts burns (DoT potency 50, 15s);
-    also used out of battle'
+    type: Magic
+    description: 'telegraphed circle AoE; inflicts burns (magic DoT potency 50,
+    15s); also used out of battle'
 notes:
   - 'Can appear on any floor from 81-89, but seems fairly rare in the earlier
     floors, and much more common in the later floors'

--- a/_potd_081_enemies/eruca.md
+++ b/_potd_081_enemies/eruca.md
@@ -19,7 +19,9 @@ vulnerabilities:
 abilities:
   - name: Incinerate
     potency: 300
-    description: 'telegraphed conal AoE; inflicts burns (DoT potency 30, 24s)'
+    type: Magic
+    description: 'telegraphed conal AoE; inflicts burns (magic DoT potency 30,
+    24s)'
 job_specifics:
   SGE:
     difficulty: Easy

--- a/_potd_081_enemies/gallimimus.md
+++ b/_potd_081_enemies/gallimimus.md
@@ -19,7 +19,9 @@ vulnerabilities:
 abilities:
   - name: Flash Evaporation
     potency: 300
-    description: 'telegraphed circle AoE; inflicts burns (DoT potency 100, 9s)'
+    type: Magic
+    description: 'telegraphed circle AoE; inflicts burns (magic DoT potency
+    100, 9s)'
 job_specifics:
   SGE:
     difficulty: Easy

--- a/_potd_081_enemies/hapalit.md
+++ b/_potd_081_enemies/hapalit.md
@@ -19,9 +19,11 @@ vulnerabilities:
 abilities:
   - name: Straight Punch
     potency: 130
+    type: Physical
     description: 'instant'
   - name: 'Elbow Drop'
     potency: 300
+    type: Physical
     description: 'telegraphed backward conal AoE; used when someone is behind'
 job_specifics:
   SGE:

--- a/_potd_081_enemies/mimic.md
+++ b/_potd_081_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Infatuation
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_081_enemies/vinegaroon.md
+++ b/_potd_081_enemies/vinegaroon.md
@@ -18,9 +18,11 @@ vulnerabilities:
 abilities:
   - name: Third Leg Forward
     potency: 300
+    type: Physical
     description: 'telegraphed conal AoE'
   - name: Third Leg Back
     potency: 300
+    type: Physical
     description: 'telegraphed backward conal AoE; inflicts knockback; used
     after Third Leg Forward if someone is behind'
 job_specifics:

--- a/_potd_081_enemies/wamoura.md
+++ b/_potd_081_enemies/wamoura.md
@@ -19,7 +19,9 @@ vulnerabilities:
 abilities:
   - name: Poison Dust
     potency: 300
-    description: 'telegraphed conal AoE; inflicts poison (DoT potency 60, 15s)'
+    type: Magic
+    description: 'telegraphed conal AoE; inflicts poison (magic DoT potency 60,
+    15s)'
 job_specifics:
   SGE:
     difficulty: Easy

--- a/_potd_081_enemies/wamouracampa.md
+++ b/_potd_081_enemies/wamouracampa.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Cannonball
     potency: 130
+    type: Magic
     description: 'instant ranged attack'
 job_specifics:
   SGE:

--- a/_potd_081_enemies/worm.md
+++ b/_potd_081_enemies/worm.md
@@ -18,9 +18,11 @@ vulnerabilities:
 abilities:
   - name: 'Sand Cyclone'
     potency: 90
-    description: 'instant; inflicts sludge (DoT potency 20, 12s)'
+    type: Magic
+    description: 'instant; inflicts sludge (magic DoT potency 20, 12s)'
   - name: Sand Breath
     potency: 300
+    type: Unique
     description: 'telegraphed conal AoE; inflicts blind (10s)'
 job_specifics:
   SGE:

--- a/_potd_091_enemies/corse.md
+++ b/_potd_091_enemies/corse.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Glass Punch
     potency: 150
+    type: Physical
     description: 'instant'
 job_specifics:
   SGE:

--- a/_potd_091_enemies/dragon.md
+++ b/_potd_091_enemies/dragon.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Dark Thorn
     potency: 90
+    type: Magic
     description: 'telegraphed circle AoE; also used out of battle, with potency
     300'
 notes:

--- a/_potd_091_enemies/gourmand.md
+++ b/_potd_091_enemies/gourmand.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Beatdown
     potency: 150
+    type: Physical
     description: 'instant'
   - name: 'Dirty Sneeze'
     potency: 130?

--- a/_potd_091_enemies/gravekeeper.md
+++ b/_potd_091_enemies/gravekeeper.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Nail in the Coffin
     potency: 150
+    type: Physical
     description: 'instant'
   - name: Vengeance Soul
     potency: 130

--- a/_potd_091_enemies/hippocerf.md
+++ b/_potd_091_enemies/hippocerf.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Shriek
     potency: 200
+    type: Magic
     description: 'telegraphed pointblank AoE; inflicts stun (6s)'
 job_specifics:
   SGE:

--- a/_potd_091_enemies/iron_corse.md
+++ b/_potd_091_enemies/iron_corse.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Butterfly Float
     potency: 150
+    type: Physical
     description: 'instant gap closer'
 job_specifics:
   SGE:

--- a/_potd_091_enemies/mimic.md
+++ b/_potd_091_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Infatuation
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_091_enemies/mummy.md
+++ b/_potd_091_enemies/mummy.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Rotting Bandages
     potency: 130
+    type: Physical
     description: 'telegraphed conal AoE; inflicts stun (6s)'
 job_specifics:
   SGE:

--- a/_potd_091_enemies/roselet.md
+++ b/_potd_091_enemies/roselet.md
@@ -19,9 +19,11 @@ vulnerabilities:
 abilities:
   - name: Seedvolley
     potency: 100
+    type: Physical
     description: 'instant'
   - name: Swift Sough
     potency: 300
+    type: Magic
     description: 'telegraphed conal AoE; inflicts knockback'
 job_specifics:
   SGE:

--- a/_potd_091_enemies/wraith.md
+++ b/_potd_091_enemies/wraith.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Scream
     potency: 200
+    type: Magic
     description: 'huge telegraphed pointblank AoE; inflicts terror (15s); can
     be interrupted'
 job_specifics:

--- a/_potd_101_enemies/beetle.md
+++ b/_potd_101_enemies/beetle.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Rhino Attack
     potency: 250
+    type: Physical
     description: 'gap closer (can be LoSed)'
   - name: Rhino Guard
     potency: n/a

--- a/_potd_101_enemies/doblyn.md
+++ b/_potd_101_enemies/doblyn.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Shatter
     potency: 300
+    type: Magic
     description: 'telegraphed pointblank AoE'
 job_specifics:
   SGE:

--- a/_potd_101_enemies/gaelicat.md
+++ b/_potd_101_enemies/gaelicat.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Scratch Fever
     potency: 130
+    type: Physical
     description: 'instant'
   - name: Yowl
     potency: n/a

--- a/_potd_101_enemies/goblin.md
+++ b/_potd_101_enemies/goblin.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Goblin Rush
     potency: 50 (x3)
+    type: Physical
     description: 'instant 3-hit attack'
 job_specifics:
   SGE:

--- a/_potd_101_enemies/hippogryph.md
+++ b/_potd_101_enemies/hippogryph.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Shriek
     potency: 200
+    type: Magic
     description: 'telegraphed pointblank AoE; inflicts stun (6s)'
 job_specifics:
   SGE:

--- a/_potd_101_enemies/hornet.md
+++ b/_potd_101_enemies/hornet.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Final Sting
     potency: 99% of max HP
+    type: Unique
     description: 'sacrificial enrage; possible to outrange; used at 22-second
     intervals'
 job_specifics:

--- a/_potd_101_enemies/ladybug.md
+++ b/_potd_101_enemies/ladybug.md
@@ -18,7 +18,7 @@ vulnerabilities:
 abilities:
   - name: Spoil
     potency: n/a
-    description: 'inflicts poison (DoT potency 20, 15s)'
+    description: 'inflicts poison (unique DoT potency 20, 15s)'
 job_specifics:
   SGE:
     difficulty: Easy

--- a/_potd_101_enemies/mimic.md
+++ b/_potd_101_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Infatuation
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_101_enemies/stag.md
+++ b/_potd_101_enemies/stag.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Big Horn
     potency: 130
+    type: Physical
     description: 'instant'
 job_specifics:
   SGE:

--- a/_potd_111_enemies/bifericeras.md
+++ b/_potd_111_enemies/bifericeras.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Palsynyxis
     potency: 300
+    type: Magic
     description: 'telegraphed conal AoE; inflicts paralysis (15s)'
 job_specifics:
   SGE:

--- a/_potd_111_enemies/biloko.md
+++ b/_potd_111_enemies/biloko.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: The Wood Remembers
     potency: 300
+    type: Physical
     description: 'telegraphed conal AoE'
   - name: Stoneskin
     potency: n/a

--- a/_potd_111_enemies/cobra.md
+++ b/_potd_111_enemies/cobra.md
@@ -19,9 +19,11 @@ vulnerabilities:
 abilities:
   - name: Regorge
     potency: 130
-    description: 'instant; inflicts poison (DoT potency 60, 15s)'
+    type: Magic
+    description: 'instant; inflicts poison (magic DoT potency 60, 15s)'
   - name: Devour
     potency: 100% of max HP
+    type: Unique
     description: 'instant death; only used if you are a toad'
 job_specifics:
   SGE:

--- a/_potd_111_enemies/gigantoad.md
+++ b/_potd_111_enemies/gigantoad.md
@@ -19,11 +19,13 @@ vulnerabilities:
 abilities:
   - name: Sticky Tongue
     potency: 50
+    type: Physical
     description: 'instant; draws the target in, and inflicts stun (6s) if
     looking AWAY from the toad - be sure to face toward the toad so you can
     escape Labored Leap'
   - name: Labored Leap
     potency: 500
+    type: Physical
     description: 'telegraphed pointblank AoE; used immediately after Sticky
     Tongue'
 job_specifics:

--- a/_potd_111_enemies/leech.md
+++ b/_potd_111_enemies/leech.md
@@ -18,8 +18,9 @@ vulnerabilities:
 abilities:
   - name: Drowning Mist
     potency: 300
-    description: 'telegraphed pointblank AoE; inflicts poison (DoT potency 50,
-    15s)'
+    type: Magic
+    description: 'telegraphed pointblank AoE; inflicts dropsy (magic DoT
+    potency 50, 15s)'
 job_specifics:
   SGE:
     difficulty: Easy

--- a/_potd_111_enemies/mimic.md
+++ b/_potd_111_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Infatuation
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_111_enemies/morbol.md
+++ b/_potd_111_enemies/morbol.md
@@ -28,7 +28,7 @@ notes:
     Breath AoE after waking up from Sweet Breath'
   - note: 'Bad Breath inflicts these debuffs:'
     subnotes:
-      - 'Poison (DoT potency 50, 30s)'
+      - 'Poison (unique DoT potency 50, 30s)'
       - 'Nausea (20s)'
       - 'Slow (10s)'
       - 'Blind (30s)'

--- a/_potd_111_enemies/nanka.md
+++ b/_potd_111_enemies/nanka.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Brackish Drop
     potency: 600
+    type: Magic
     description: 'telegraphed circle AoE; also used out of combat'
 job_specifics:
   SGE:

--- a/_potd_111_enemies/ochu.md
+++ b/_potd_111_enemies/ochu.md
@@ -17,9 +17,10 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Gold Dust
-    potency: n/a
-    description: 'telegraphed large circle AoE; inflicts poison (DoT potency
-    60, 15s)'
+    potency: 300
+    type: Magic
+    description: 'telegraphed large circle AoE; inflicts poison (magic DoT
+    potency 60, 15s)'
 job_specifics:
   SGE:
     difficulty: Easy

--- a/_potd_111_enemies/pudding.md
+++ b/_potd_111_enemies/pudding.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Amorphic Flail
     potency: 130
+    type: Physical
     description: 'instant pointblank AoE'
 job_specifics:
   SGE:

--- a/_potd_111_enemies/seedling.md
+++ b/_potd_111_enemies/seedling.md
@@ -16,8 +16,8 @@ vulnerabilities:
   stun: true
   resolution: false
 notes:
-  - 'Autoattack inflicts stacking poison (DoT potency 10 per stack, max 4
-    stacks, 9s)'
+  - 'Autoattack inflicts stacking poison (physical DoT potency 10 per stack,
+    max 4 stacks, 9s)'
 job_specifics:
   SGE:
     difficulty: Easy

--- a/_potd_111_enemies/slime.md
+++ b/_potd_111_enemies/slime.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: 'Rapture'
     potency: 99% of max HP
+    type: Unique
     description: 'instant AoE sacrificial enrage; used 37 seconds after pull'
 notes:
   - 'Acid Spray inflicts stacking physical vulnerability up (+10% per stack,

--- a/_potd_121_enemies/adamantoise.md
+++ b/_potd_121_enemies/adamantoise.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Tortoise Stomp
     potency: 500
+    type: Physical
     description: 'large telegraphed pointblank AoE'
   - name: 'Harden Shell'
     potency: n/a

--- a/_potd_121_enemies/basilisk.md
+++ b/_potd_121_enemies/basilisk.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Body Slam
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
   - name: Stone Gaze
     potency: n/a

--- a/_potd_121_enemies/biast.md
+++ b/_potd_121_enemies/biast.md
@@ -18,10 +18,12 @@ vulnerabilities:
 abilities:
   - name: Levinfang
     potency: 130
+    type: Physical
     description: 'instant; inflicts paralysis (30s); has to be close to use
     this, so ranged DPS can avoid by kiting with Sprint and/or Leg Graze'
   - name: Electrify
     potency: 300
+    type: Unique
     description: 'telegraphed circle AoE; short cast'
 notes:
   - 'Uses Levinfang immediately followed by Electrify shortly after pull. If

--- a/_potd_121_enemies/centaur.md
+++ b/_potd_121_enemies/centaur.md
@@ -21,6 +21,7 @@ abilities:
     description: 'grants physical damage up (50%, 20s) to self'
   - name: Rear
     potency: 300
+    type: Magic
     description: 'telegraphed pointblank AoE'
 job_specifics:
   SGE:

--- a/_potd_121_enemies/dullahan.md
+++ b/_potd_121_enemies/dullahan.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Iron Justice
     potency: 300
+    type: Physical
     description: 'telegraphed conal AoE'
   - name: 'Blade of Suffering'
     potency: n/a

--- a/_potd_121_enemies/effigy.md
+++ b/_potd_121_enemies/effigy.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Wild Horn
     potency: 200
+    type: Physical
     description: 'large telegraphed conal AoE; inflicts knockback'
 job_specifics:
   SGE:

--- a/_potd_121_enemies/mimic.md
+++ b/_potd_121_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Infatuation
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_121_enemies/minotaur.md
+++ b/_potd_121_enemies/minotaur.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: '111-tonze Swing'
     potency: 600
+    type: Physical
     description: 'untelegraphed pointblank AoE; inflicts knockback'
 job_specifics:
   SGE:

--- a/_potd_121_enemies/pteroc.md
+++ b/_potd_121_enemies/pteroc.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Tail Chase
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 job_specifics:
   SGE:

--- a/_potd_121_enemies/spriggan.md
+++ b/_potd_121_enemies/spriggan.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: 'Fast Boulder'
     potency: 300
+    type: Magic
     description: 'telegraphed circle AoE; also used out of combat'
   - name: Haste
     potency: n/a

--- a/_potd_121_enemies/urolith.md
+++ b/_potd_121_enemies/urolith.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Tornado
     potency: 120
+    type: Magic
     description: 'untelegraphed circle AoE; can be interrupted, but it''s a
     very quick cast'
 job_specifics:

--- a/_potd_121_enemies/wivre.md
+++ b/_potd_121_enemies/wivre.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Brow Horn
     potency: 130
+    type: Physical
     description: 'instant'
 job_specifics:
   SGE:

--- a/_potd_131_enemies/catoblepas.md
+++ b/_potd_131_enemies/catoblepas.md
@@ -23,6 +23,7 @@ abilities:
     away, get behind, or get away'
   - name: 'Jettatura'
     potency: 300
+    type: Magic
     description: 'telegraphed circle AoE'
 job_specifics:
   SGE:

--- a/_potd_131_enemies/dahak.md
+++ b/_potd_131_enemies/dahak.md
@@ -18,11 +18,13 @@ vulnerabilities:
 abilities:
   - name: 'Rotten Breath'
     potency: 120
+    type: Magic
     description: 'inflicts disease (30s)'
   - name: 'Tail Drive (?)'
     potency: 300
-    description: 'telegraphed backward conal AoE inflicting concussion (DoT
-    potency 30, 15s); used if someone is behind'
+    type: Physical
+    description: 'telegraphed backward conal AoE inflicting concussion
+    (physical DoT potency 30, 15s); used if someone is behind'
 job_specifics:
   SGE:
     difficulty: Easy

--- a/_potd_131_enemies/gourmand.md
+++ b/_potd_131_enemies/gourmand.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Beatdown
     potency: 130
+    type: Physical
     description: 'instant'
 job_specifics:
   SGE:

--- a/_potd_131_enemies/guard.md
+++ b/_potd_131_enemies/guard.md
@@ -18,9 +18,11 @@ vulnerabilities:
 abilities:
   - name: Void Slash
     potency: 100
+    type: Physical
     description: 'instant'
   - name: Void Trap
     potency: 300
+    type: Magic
     description: 'telegraphed circle AoE'
 job_specifics:
   SGE:

--- a/_potd_131_enemies/hecteyes.md
+++ b/_potd_131_enemies/hecteyes.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Hex Eye
     potency: 200
+    type: Magic
     description: 'telegraphed pointblank AoE; inflicts paralysis (15s)'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'

--- a/_potd_131_enemies/mimic.md
+++ b/_potd_131_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Infatuation
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_131_enemies/monk.md
+++ b/_potd_131_enemies/monk.md
@@ -23,6 +23,7 @@ abilities:
     description: 'large untelegraphed pointblank AoE; draws players in'
   - name: Flood
     potency: 350
+    type: Magic
     description: 'telegraphed pointblank AoE; used immediately after Sucker'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'

--- a/_potd_131_enemies/mummy.md
+++ b/_potd_131_enemies/mummy.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Rotting Bandages
     potency: 130
+    type: Physical
     description: 'telegraphed conal AoE; inflicts stun (6s)'
 job_specifics:
   SGE:

--- a/_potd_131_enemies/ogre.md
+++ b/_potd_131_enemies/ogre.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Heartburn
     potency: 300
+    type: Magic
     description: 'large telegraphed circle AoE'
 job_specifics:
   SGE:

--- a/_potd_131_enemies/soul.md
+++ b/_potd_131_enemies/soul.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Curse
     potency: 200
+    type: Magic
     description: 'telegraphed pointblank AoE; also deals 500 MP damage'
 job_specifics:
   SGE:

--- a/_potd_131_enemies/taurus.md
+++ b/_potd_131_enemies/taurus.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Triclip
     potency: 120
+    type: Physical
     description: 'instant'
   - name: Voidblood
     potency: n/a

--- a/_potd_141_enemies/demon.md
+++ b/_potd_141_enemies/demon.md
@@ -18,9 +18,11 @@ vulnerabilities:
 abilities:
   - name: Dark Dome
     potency: 90
+    type: Magic
     description: 'instant'
   - name: Charybdis
     potency: 90% of current HP
+    type: Unique
     description: 'enrage; can be interrupted'
 job_specifics:
   MCH:

--- a/_potd_141_enemies/dragon.md
+++ b/_potd_141_enemies/dragon.md
@@ -18,10 +18,12 @@ vulnerabilities:
 abilities:
   - name: Evil Eye
     potency: 300
+    type: Magic
     description: 'conal gaze AoE inflicting terror (5s) - look away, get
     behind, or get away'
   - name: Miasma Breath
     potency: 300
+    type: Magic
     description: 'telegraphed conal AoE; inflicts disease (15s)'
 job_specifics:
   MCH:

--- a/_potd_141_enemies/gargoyle.md
+++ b/_potd_141_enemies/gargoyle.md
@@ -18,9 +18,11 @@ vulnerabilities:
 abilities:
   - name: Corrupted Tail
     potency: 100
-    description: 'instant; inflicts poison (DoT potency 55, 20s)'
+    type: Physical
+    description: 'instant; inflicts poison (physical DoT potency 55, 20s)'
   - name: Grim Fate
     potency: 130
+    type: Physical
     description: 'instant'
 notes:
   - 'Hits pretty hard - watch out for poison damage'

--- a/_potd_141_enemies/hellhound.md
+++ b/_potd_141_enemies/hellhound.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Ravenous Bite
     potency: 110
+    type: Physical
     description: 'instant'
 job_specifics:
   MCH:

--- a/_potd_141_enemies/ked.md
+++ b/_potd_141_enemies/ked.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Thunderstrike
     potency: 300
+    type: Magic
     description: 'telegraphed line AoE'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'

--- a/_potd_141_enemies/keeper.md
+++ b/_potd_141_enemies/keeper.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Nail in the Coffin
     potency: 150
+    type: Physical
     description: 'instant'
 job_specifics:
   MCH:

--- a/_potd_141_enemies/knight.md
+++ b/_potd_141_enemies/knight.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Skullsplinter
     potency: 130
+    type: Physical
     description: 'instant'
   - name: Ossify
     potency: n/a

--- a/_potd_141_enemies/manticore.md
+++ b/_potd_141_enemies/manticore.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Wild Charge
     potency: 130
+    type: Physical
     description: 'instant gap closer; used immediately on pull, and again when
     its damage down debuff (see next ability) wears off'
   - name: 'Bloodboil'
@@ -28,9 +29,11 @@ abilities:
     debuff (60%, 30s)'
   - name: Ripper Claw
     potency: 300
+    type: Physical
     description: 'untelegraphed conal AoE - don''t stand in front!'
   - name: Fireball
     potency: 300
+    type: Magic
     description: 'telegraphed circle AoE'
 notes:
   - 'Hits pretty hard with the attack bonus'

--- a/_potd_141_enemies/mimic.md
+++ b/_potd_141_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Infatuation
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_141_enemies/succubus.md
+++ b/_potd_141_enemies/succubus.md
@@ -18,9 +18,11 @@ vulnerabilities:
 abilities:
   - name: Dark Mist
     potency: 300
+    type: Magic
     description: 'large telegraphed pointblank AoE; inflicts terror (10s)'
   - name: Void Fire IV
     potency: 350
+    type: Magic
     description: 'large telegraphed circle AoE; used immediately after Dark
     Mist; also used out of battle'
 job_specifics:

--- a/_potd_141_enemies/wraith.md
+++ b/_potd_141_enemies/wraith.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Scream
     potency: 200
+    type: Magic
     description: 'huge telegraphed pointblank AoE; inflicts terror (10s); can
     be interrupted'
 job_specifics:

--- a/_potd_151_enemies/abaia.md
+++ b/_potd_151_enemies/abaia.md
@@ -18,7 +18,8 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Terror Eye
-    potency: n/a
+    potency: 300
+    type: Magic
     description: 'telegraphed circle AoE; also used out of combat'
   - name: 'Triumphant Roar'
     potency: n/a

--- a/_potd_151_enemies/arch_demon.md
+++ b/_potd_151_enemies/arch_demon.md
@@ -19,10 +19,12 @@ vulnerabilities:
 abilities:
   - name: Abyssal Swing
     potency: 300
+    type: Physical
     description: 'telegraphed conal AoE. Try to stay very near or far when
     paralyzed, so you don''t get caught in the middle of this'
   - name: Abyssal Transfixion
     potency: 130
+    type: Physical
     description: 'instant; inflicts paralysis (30s)'
 notes:
   - 'If there are several, you may want to pull them in quick succession to

--- a/_potd_151_enemies/deepeye.md
+++ b/_potd_151_enemies/deepeye.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Optical Intrusion
     potency: 130
+    type: Physical
     description: 'instant'
   - name: Hypnotize
     potency: n/a

--- a/_potd_151_enemies/devilet.md
+++ b/_potd_151_enemies/devilet.md
@@ -20,11 +20,12 @@ vulnerabilities:
 abilities:
   - name: Ice Spikes
     potency: n/a
-    description: 'Grants counterattack (potency 200, 5s) to self; can be
+    description: 'Grants counterattack (magic potency 200, 5s) to self; can be
     interrupted. Recommended to interrupt or disengage immediately. The damage
     can kill you very quickly'
   - name: Void Blizzard
     potency: 130
+    type: Magic
     description: 'Inflicts slow (20s); can be interrupted. It only has medium
     range, so you can also run away to avoid it'
 notes:

--- a/_potd_151_enemies/gremlin.md
+++ b/_potd_151_enemies/gremlin.md
@@ -21,6 +21,7 @@ abilities:
     description: 'instant; inflicts vulnerability up (25%, 10s)'
   - name: Fire II
     potency: 300
+    type: Magic
     description: 'telegraphed circle AoE'
 job_specifics:
   GNB:

--- a/_potd_151_enemies/marolith.md
+++ b/_potd_151_enemies/marolith.md
@@ -19,9 +19,11 @@ vulnerabilities:
 abilities:
   - name: Carpomission
     potency: 130
+    type: Physical
     description: 'instant'
   - name: Isle Drop
     potency: 300
+    type: Physical
     description: 'telegraphed circle AoE; inflicts stun (5s)'
 job_specifics:
   GNB:

--- a/_potd_151_enemies/mimic.md
+++ b/_potd_151_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Infatuation
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_151_enemies/pot.md
+++ b/_potd_151_enemies/pot.md
@@ -18,9 +18,11 @@ vulnerabilities:
 abilities:
   - name: Mysterious Light
     potency: 400
+    type: Magic
     description: 'roomwide gaze attack inflicting blind (15s) - look away'
   - name: Double Ray
     potency: 120
+    type: Magic
     description: 'instant'
 job_specifics:
   GNB:

--- a/_potd_151_enemies/pudding.md
+++ b/_potd_151_enemies/pudding.md
@@ -20,6 +20,7 @@ vulnerabilities:
 abilities:
   - name: Amorphic Flail
     potency: 130
+    type: Physical
     description: 'instant pointblank AoE'
 notes:
   - 'Caster, but also does melee attacks if you''re close. Keeping distance

--- a/_potd_151_enemies/shabti.md
+++ b/_potd_151_enemies/shabti.md
@@ -20,6 +20,7 @@ vulnerabilities:
 abilities:
   - name: 'Death''s Door'
     potency: 400
+    type: Physical
     description: 'quick, long, narrow line AoE. It will spam this every few
     seconds'
 job_specifics:

--- a/_potd_151_enemies/soulflayer.md
+++ b/_potd_151_enemies/soulflayer.md
@@ -18,9 +18,11 @@ vulnerabilities:
 abilities:
   - name: Mind Blast
     potency: 300
+    type: Magic
     description: 'telegraphed pointblank AoE; inflicts paralysis (15s)'
   - name: Drain Touch
     potency: 130
+    type: Physical
     description: 'instant; absorbs 100% of damage dealt'
 notes:
   - Caster - kiting doesn't help to mitigate damage

--- a/_potd_151_enemies/taurus.md
+++ b/_potd_151_enemies/taurus.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Frightful Roar
     potency: 300
+    type: Magic
     description: 'telegraphed pointblank AoE; inflicts vulnerability up (20%,
     30s)'
 job_specifics:

--- a/_potd_161_enemies/archaeosaur.md
+++ b/_potd_161_enemies/archaeosaur.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Underbite
     potency: 130
+    type: Physical
     description: 'instant'
   - name: Primordial Bark
     description: 'telegraphed pointblank AoE'

--- a/_potd_161_enemies/croc.md
+++ b/_potd_161_enemies/croc.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Crushing Fangs
     potency: 130
+    type: Physical
     description: 'instant'
 notes:
   - Hits pretty hard

--- a/_potd_161_enemies/lindwurm.md
+++ b/_potd_161_enemies/lindwurm.md
@@ -19,7 +19,9 @@ vulnerabilities:
 abilities:
   - name: Foul Breath
     potency: 300
-    description: 'telegraphed conal AoE; inflicts burns (DoT potency 30, 12s)'
+    type: Unique
+    description: 'telegraphed conal AoE; inflicts burns (unique DoT potency
+    30, 12s)'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_161_enemies/mimic.md
+++ b/_potd_161_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Infatuation
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_161_enemies/mylodon.md
+++ b/_potd_161_enemies/mylodon.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Slowball
     potency: 130
+    type: Magic
     description: 'instant circle AoE'
   - name: Snow Flurry
     description: 'telegraphed conal AoE'

--- a/_potd_161_enemies/pteranodon.md
+++ b/_potd_161_enemies/pteranodon.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Lightning Bolt
     potency: 300
+    type: Magic
     description: 'telegraphed circle AoE'
 job_specifics:
   GNB:

--- a/_potd_161_enemies/sarcosuchus.md
+++ b/_potd_161_enemies/sarcosuchus.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Critical Bite
     potency: 300
+    type: Physical
     description: 'telegraphed conal AoE'
 job_specifics:
   GNB:

--- a/_potd_161_enemies/triceratops.md
+++ b/_potd_161_enemies/triceratops.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Batterhorn
     potency: 130
+    type: Physical
     description: 'instant'
 notes:
   - Hits pretty hard

--- a/_potd_161_enemies/tursus.md
+++ b/_potd_161_enemies/tursus.md
@@ -19,10 +19,12 @@ vulnerabilities:
 abilities:
   - name: Chilling Cyclone
     potency: 300
-    description: 'telegraphed conal AoE; inflicts deep freeze (DoT potency 50,
-    9s)'
+    type: Magic
+    description: 'telegraphed conal AoE; inflicts deep freeze (magic DoT
+    potency 50, 9s)'
   - name: Ice Dispenser
     potency: 130
+    type: Magic
     description: 'instant circle AoE; inflicts slow (15s)'
 notes:
   - 'If there are several, you may want to pull them in quick succession to

--- a/_potd_161_enemies/vinegaroon.md
+++ b/_potd_161_enemies/vinegaroon.md
@@ -19,9 +19,11 @@ vulnerabilities:
 abilities:
   - name: Third Leg Forward
     potency: 300?
+    type: Physical
     description: 'telegraphed conal AoE'
   - name: Third Leg Back
     potency: 300?
+    type: Physical
     description: 'telegraphed backward conal AoE; inflicts knockback. Used
     after Third Leg Forward if someone is behind, and will use it over and
     over as long as someone is behind it.'

--- a/_potd_161_enemies/wivre.md
+++ b/_potd_161_enemies/wivre.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Brow Horn
     potency: 130
+    type: Physical
     description: 'instant'
 notes:
   - Hits pretty hard

--- a/_potd_171_enemies/anzu.md
+++ b/_potd_171_enemies/anzu.md
@@ -18,9 +18,10 @@ vulnerabilities:
 abilities:
   - name: 'Sonic Boom'
     potency: n/a
-    description: 'instant; inflicts windburn (DoT potency 15, 20s)'
+    description: 'instant; inflicts windburn (physical DoT potency 15, 20s)'
   - name: Flying Frenzy
     potency: 180
+    type: Physical
     description: 'instant circle AoE gap closer; inflicts stun (2s) and
     vulnerability up (50%, 10s). Diminishing returns do NOT apply to this stun
     (it is always 2s)'

--- a/_potd_171_enemies/bandersnatch.md
+++ b/_potd_171_enemies/bandersnatch.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Catching Claws
     potency: 130
+    type: Physical
     description: 'instant'
 notes:
   - Hits pretty hard

--- a/_potd_171_enemies/bear.md
+++ b/_potd_171_enemies/bear.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Savage Swipe
     potency: 300
+    type: Physical
     description: 'telegraphed conal AoE'
 job_specifics:
   GNB:

--- a/_potd_171_enemies/bird.md
+++ b/_potd_171_enemies/bird.md
@@ -19,9 +19,11 @@ vulnerabilities:
 abilities:
   - name: Filoplumes
     potency: 130
+    type: Physical
     description: 'instant'
   - name: Revelation
     potency: 300
+    type: Physical
     description: 'telegraphed circle AoE; inflicts confused (10s)'
   - name: Tropical Wind
     potency: n/a

--- a/_potd_171_enemies/coeurl.md
+++ b/_potd_171_enemies/coeurl.md
@@ -17,6 +17,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Megablaster
+    type: Magic
     description: 'telegraphed conal AoE. Doesn''t use this while you''re
     paralyzed'
   - name: 'Blaster'

--- a/_potd_171_enemies/dhalmel.md
+++ b/_potd_171_enemies/dhalmel.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Whiplash
     potency: 300
+    type: Physical
     description: 'telegraphed conal AoE'
   - name: Whistle
     potency: n/a

--- a/_potd_171_enemies/lion.md
+++ b/_potd_171_enemies/lion.md
@@ -18,9 +18,11 @@ vulnerabilities:
 abilities:
   - name: Mark of the Beast
     potency: 130
+    type: Physical
     description: 'instant'
   - name: Cry
     potency: 300?
+    type: Magic
     description: 'large telegraphed pointblank AoE'
 job_specifics:
   GNB:

--- a/_potd_171_enemies/mimic.md
+++ b/_potd_171_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Infatuation
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_171_enemies/sasquatch.md
+++ b/_potd_171_enemies/sasquatch.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Browbeat
     potency: 200
+    type: Physical
     description: 'instant'
   - name: Ripe Banana
     potency: n/a
@@ -26,6 +27,7 @@ abilities:
     Thump every few seconds until the buff expires'
   - name: Chest Thump
     potency: n/a
+    type: Magic
     description: 'huge 1.5 room instant AoE that inflicts stacking physical
     vulnerability up (10% per stack, max 5 stacks, 8s). Only used out of combat
     during Ripe Banana'

--- a/_potd_171_enemies/snowclops.md
+++ b/_potd_171_enemies/snowclops.md
@@ -23,6 +23,7 @@ abilities:
     description: 'untelegraphed wide line AoE - DO NOT stand in front'
   - name: 100-tonze Swing
     potency: 600?
+    type: Physical
     description: 'untelegraphed pointblank AoE inflicting knockback - get away'
 job_specifics:
   GNB:

--- a/_potd_171_enemies/wolf.md
+++ b/_potd_171_enemies/wolf.md
@@ -18,8 +18,9 @@ vulnerabilities:
 abilities:
   - name: Sanguine Bite
     potency: 130
+    type: Physical
     description: 'instant; absorbs 100% of damage dealt; inflicts frostbite
-    (DoT potency 50, 12s)'
+    (physical DoT potency 50, 12s)'
 notes:
   - Hits pretty hard
   - 'Doesn''t stop to use any abilities, so the damage is constant'

--- a/_potd_181_enemies/archaeosaur.md
+++ b/_potd_181_enemies/archaeosaur.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Underbite
     potency: 130
+    type: Physical
     description: 'instant'
   - name: Primordial Bark
     description: 'telegraphed pointblank AoE'

--- a/_potd_181_enemies/claw.md
+++ b/_potd_181_enemies/claw.md
@@ -23,8 +23,10 @@ abilities:
     immunity does not work against the draw-in'
   - name: Impale
     potency: 130
+    type: Physical
     description: 'used against players with prey; clears prey status'
   - name: Tail Screw
+    type: Magic
     description: 'inflicts slow; can be outranged'
 notes:
   - 'Does a draw-in that applies Prey status followed by Impale. Knockback

--- a/_potd_181_enemies/crawler.md
+++ b/_potd_181_enemies/crawler.md
@@ -18,10 +18,12 @@ vulnerabilities:
 abilities:
   - name: 'Sticky Thread'
     potency: 120
+    type: Magic
     description: 'instant conal AoE; inflicts slow (30s)'
   - name: 'Poison Breath (?)'
     potency: n/a
-    description: 'instant conal AoE; inflicts poison (DoT potency 60, 20s)'
+    description: 'instant conal AoE; inflicts poison (magic DoT potency 60,
+    20s)'
 job_specifics:
   GNB:
     difficulty: Medium

--- a/_potd_181_enemies/dragon.md
+++ b/_potd_181_enemies/dragon.md
@@ -18,7 +18,9 @@ vulnerabilities:
 abilities:
   - name: 'Sheet of Ice'
     potency: 120
-    description: 'instant circle AoE; inflicts frostbite (DoT potency 100, 21s)'
+    type: Magic
+    description: 'instant circle AoE; inflicts frostbite (magic DoT potency
+    100, 21s)'
   - name: 'Granite Rain'
     description: telegraphed pointblank AoE
 job_specifics:

--- a/_potd_181_enemies/garm.md
+++ b/_potd_181_enemies/garm.md
@@ -29,12 +29,15 @@ abilities:
     interrupted'
   - name: 'The Dragon''s Breath'
     potency: 300?
+    type: Unique
     description: 'telegraphed conal AoE'
   - name: 'The Lion''s Breath'
     potency: 300?
+    type: Unique
     description: 'telegraphed conal AoE'
   - name: 'The Ram''s Breath'
     potency: 300?
+    type: Unique
     description: 'telegraphed conal AoE'
 notes:
   - 'These mostly just spam abilities, doing very little auto-attack damage'

--- a/_potd_181_enemies/mimic.md
+++ b/_potd_181_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Infatuation
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_181_enemies/wamoura.md
+++ b/_potd_181_enemies/wamoura.md
@@ -18,6 +18,7 @@ vulnerabilities:
   resolution: false
 abilities:
   - name: Poison Dust
+    type: Magic
     description: 'telegraphed conal AoE; inflicts poison'
   - name: Exuviation
     potency: n/a

--- a/_potd_181_enemies/wamouracampa.md
+++ b/_potd_181_enemies/wamouracampa.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Cannonball
     potency: 130
+    type: Magic
     description: 'instant ranged attack'
 job_specifics:
   GNB:

--- a/_potd_181_enemies/worm.md
+++ b/_potd_181_enemies/worm.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Sand Pillar
     potency: 120
+    type: Magic
     description: 'instant circle AoE. Also used out of combat, with potency 75;
     be very careful if there are several worms nearby, as getting hit by a few
     of these at once could kill you'

--- a/_potd_191_enemies/bicephalus.md
+++ b/_potd_191_enemies/bicephalus.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Glass Punch
     potency: 150
+    type: Physical
     description: 'instant'
   - name: Catapult
     description: 'telegraphed circle AoE'

--- a/_potd_191_enemies/gourmand.md
+++ b/_potd_191_enemies/gourmand.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Beatdown
     potency: 130
+    type: Physical
     description: 'instant'
   - name: 'Dirty Sneeze'
     potency: 130?

--- a/_potd_191_enemies/hippogryph.md
+++ b/_potd_191_enemies/hippogryph.md
@@ -21,6 +21,7 @@ abilities:
     description: 'instant'
   - name: Shriek
     potency: 200
+    type: Magic
     description: 'telegraphed pointblank AoE; probably inflicts stun (6s)'
 job_specifics:
   GNB:

--- a/_potd_191_enemies/iron_corse.md
+++ b/_potd_191_enemies/iron_corse.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Butterfly Float
     potency: 150
+    type: Physical
     description: 'instant gap closer; used on aggro and every 30 seconds
     afterward. Will destroy non-tanks if it crits'
 job_specifics:

--- a/_potd_191_enemies/keeper.md
+++ b/_potd_191_enemies/keeper.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Nail in the Coffin
     potency: 150
+    type: Physical
     description: 'instant'
   - name: Vengeance Soul
     potency: 130?

--- a/_potd_191_enemies/knight.md
+++ b/_potd_191_enemies/knight.md
@@ -18,9 +18,11 @@ vulnerabilities:
 abilities:
   - name: Skullsplinter
     potency: 130
+    type: Physical
     description: 'instant'
   - name: Death Spiral
     potency: 300
+    type: Magic
     description: scary-looking telegraphed donut AoE
   - name: Ossify
     potency: n/a

--- a/_potd_191_enemies/mimic.md
+++ b/_potd_191_enemies/mimic.md
@@ -19,9 +19,10 @@ gallery_only: true
 abilities:
   - name: Infatuation
     potency: n/a
-    description: 'inflicts pox (DoT potency 5, 10m); can be interrupted'
+    description: 'inflicts pox (magic DoT potency 5, 10m); can be interrupted'
   - name: Deathtrap
     potency: 300
+    type: Physical
     description: 'telegraphed pointblank AoE'
 notes:
   - 'Sometimes found in gold chests'

--- a/_potd_191_enemies/mummy.md
+++ b/_potd_191_enemies/mummy.md
@@ -18,6 +18,7 @@ vulnerabilities:
 abilities:
   - name: Rotting Bandages
     potency: 130?
+    type: Physical
     description: 'telegraphed conal AoE; probably inflicts stun (6s)'
 job_specifics:
   GNB:

--- a/_potd_191_enemies/trap.md
+++ b/_potd_191_enemies/trap.md
@@ -19,6 +19,7 @@ vulnerabilities:
 abilities:
   - name: Sleetvolley
     potency: 100
+    type: Physical
     description: 'instant ranged attack'
   - name: 'Swift Sough'
     description: 'telegraphed conal AoE'

--- a/_potd_191_enemies/wraith.md
+++ b/_potd_191_enemies/wraith.md
@@ -18,10 +18,12 @@ vulnerabilities:
 abilities:
   - name: Scream
     potency: 200
+    type: Magic
     description: 'huge telegraphed pointblank AoE; inflicts terror (10s); can
     be interrupted'
   - name: Accursed Pox
     potency: 400
+    type: Magic
     description: 'telegraphed circle AoE; inflicts disease (30s); can be
     interrupted. Also used outside of combat'
 notes:

--- a/_potd_floorsets/001.md
+++ b/_potd_floorsets/001.md
@@ -16,19 +16,24 @@ boss_attack_damage: 56
 boss_abilities:
   - name: Whipcrack
     potency: 180
+    type: Physical
     description: 'instant'
   - name: Stormwind
     potency: 350
+    type: Magic
     description: 'telegraphed conal AoE'
   - name: Bombination
     potency: 300
+    type: Magic
     description: 'telegraphed pointblank AoE; inflicts slow (12s)'
   - name: Lumisphere
     potency: 300
+    type: Magic
     description: 'telegraphed circle AoE'
   - name: Aero Blast
     potency: 80
-    description: 'roomwide AoE; applies windburn (DoT potency 50, 15s)'
+    type: Physical
+    description: 'roomwide AoE; applies windburn (physical DoT potency 50, 15s)'
 boss_notes:
   - note: 'Rotation:'
     subnotes:

--- a/_potd_floorsets/011.md
+++ b/_potd_floorsets/011.md
@@ -16,20 +16,23 @@ boss_attack_damage: 180
 boss_abilities:
   - name: Bloody Caress
     potency: 300
+    type: Physical
     description: 'instant'
   - name: Acid Mist
     potency: n/a
-    description: 'telegraphed pointblank AoE; inflicts poison (DoT potency 75,
-    30s)'
+    description: 'telegraphed pointblank AoE; inflicts poison (magic DoT
+    potency 75, 30s)'
   - name: Gold Dust
     potency: n/a
-    description: 'telegraphed circle AoE; inflicts poison (DoT potency 75,
-    30s)'
+    description: 'telegraphed circle AoE; inflicts poison (magic DoT potency
+    75, 30s)'
   - name: Leafstorm
     potency: 250
+    type: Physical
     description: 'roomwide AoE'
   - name: Rotten Stench
     potency: 350
+    type: Magic
     description: 'telegraphed wide line AoE'
 boss_notes:
   - note: 'Rotation:'

--- a/_potd_floorsets/021.md
+++ b/_potd_floorsets/021.md
@@ -16,16 +16,20 @@ boss_attack_damage: 324
 boss_abilities:
   - name: Dissever
     potency: 150
+    type: Physical
     description: 'instant'
   - name: Ball of Fire
     potency: 50
-    description: 'instant circle AoE on random player; leaves burn puddle (DoT
-    potency 350)'
+    type: Magic
+    description: 'instant circle AoE on random player; leaves burn puddle
+    (unique DoT potency 350)'
   - name: Ball of Ice
     potency: 50
+    type: Magic
     description: 'instant circle AoE on random player; leaves heavy puddle'
   - name: Fear Itself
     potency: 200
+    type: Magic
     description: 'roomwide donut AoE; inflicts hysteria (10s); must be
     inside/near boss''s target circle to avoid'
 boss_notes:

--- a/_potd_floorsets/031.md
+++ b/_potd_floorsets/031.md
@@ -16,19 +16,24 @@ boss_attack_damage: 455
 boss_abilities:
   - name: Ancient Eruption
     potency: 400
-    description: 'telegraphed circle AoE; leaves a bleed puddle (DoT potency
-    40)'
+    type: Magic
+    description: 'telegraphed circle AoE; leaves a bleed puddle (unique DoT
+    potency 40)'
   - name: Entropic Flame
     potency: 400
+    type: Magic
     description: 'telegraphed wide line AoE'
   - name: Accursed Pox
     potency: 260
+    type: Magic
     description: 'telegraphed circle AoE; inflicts disease (30s)'
   - name: Scream
     potency: 170
+    type: Magic
     description: 'roomwide AoE; inflicts terror (10s) and prey'
   - name: Shadow Flare
     potency: 260
+    type: Magic
     description: 'roomwide AoE'
 boss_notes:
   - note: 'Rotation:'

--- a/_potd_floorsets/041.md
+++ b/_potd_floorsets/041.md
@@ -16,16 +16,20 @@ boss_attack_damage: 562
 boss_abilities:
   - name: Dark Harvest
     potency: 120
+    type: Physical
     description: 'cleave'
   - name: In Health
     potency: 400
+    type: Unique
     description: 'either a huge donut AoE or a large pointblank AoE; pierces
     Steel and absorbs 100% of damage dealt'
   - name: In Sickness
     potency: 80
+    type: Magic
     description: 'instant (possibly circle AoE?); inflicts disease (20s)'
   - name: Black Honeymoon
     potency: 80
+    type: Magic
     description: 'roomwide AoE; adds 950 damage (Steel-piercing) for each
     player who was hit by In Health, or 9500 total damage at 5 In Health hits'
   - name: Cold Feet

--- a/_potd_floorsets/051.md
+++ b/_potd_floorsets/051.md
@@ -17,13 +17,16 @@ boss_attack_damage: 689
 boss_abilities:
   - name: Geirrothr
     potency: 80
+    type: Magic
     description: 'instant'
   - name: Hall of Sorrow
     potency: 60
-    description: 'instant large circle AoE leaving bleed puddle (DoT potency
-    70)'
+    type: Magic
+    description: 'instant large circle AoE leaving bleed puddle (unique DoT
+    potency 70)'
   - name: Valfodr
     potency: 60
+    type: Physical
     description: telegraphed charge AoE; inflicts knockback'
 boss_notes:
   - note: 'Rotation:'

--- a/_potd_floorsets/061.md
+++ b/_potd_floorsets/061.md
@@ -17,16 +17,20 @@ boss_attack_damage: 578
 boss_abilities:
   - name: Drench
     potency: 115
+    type: Magic
     description: 'instant conal AoE'
   - name: Electrogenesis
     potency: 300
+    type: Magic
     description: 'telegraphed circle AoE'
   - name: Douse
     potency: 400
+    type: Magic
     description: 'telegraphed pointblank AoE; leaves behind a puddle which
     grants haste to the boss. Standing in the puddle does NOT hurt you'
   - name: 'Fang''s End'
     potency: 110
+    type: Physical
     description: 'inflicts heavy (15s)'
 boss_notes:
   - note: 'Rotation:'

--- a/_potd_floorsets/071.md
+++ b/_potd_floorsets/071.md
@@ -17,24 +17,30 @@ boss_attack_damage: 720
 boss_abilities:
   - name: Thunderbolt
     potency: 300
+    type: Magic
     description: 'telegraphed conal AoE'
   - name: Charybdis
     potency: 300
+    type: Magic
     description: 'telegraphed circle AoE that leaves behind a tornado'
   - name: Trounce
     potency: 350
+    type: Physical
     description: 'large telegraphed conal AoE'
   - name: Ecliptic Meteor
     potency: 80% of max HP
+    type: Unique
     description: 'roomwide AoE; long cast time'
   - name: Maelstrom (tornado)
     potency: 130
+    type: Magic
     description: 'telegraphed circle AoE of double the tornado''s size that
     draws players in'
   - name: Charybdis (tornado)
     potency: 500
+    type: Magic
     description: 'used periodically against players inside the tornado;
-    inflicts windburn (DoT potency 180, 20s)'
+    inflicts windburn (magic DoT potency 180, 20s)'
 boss_notes:
   - note: 'Rotation:'
     subnotes:

--- a/_potd_floorsets/081.md
+++ b/_potd_floorsets/081.md
@@ -17,22 +17,28 @@ boss_attack_damage: 1003
 boss_abilities:
   - name: Scalding Scolding
     potency: 120
+    type: Physical
     description: 'instant'
   - name: Sap
     potency: 400
+    type: Magic
     description: 'telegraphed circle AoE'
   - name: Self-destruct (Lava Bomb)
     potency: 400
+    type: Magic
     description: 'telegraphed pointblank AoE'
   - name: Burst (Grey Bomb)
     potency: 80% of max HP
+    type: Unique
     description: 'roomwide AoE'
   - name: Frost Grenade (Grey Bomb)
     potency: 400
+    type: Magic
     description: 'telegraphed pointblank AoE inflicting stun (2s); also hits
     enemies, including the boss'
   - name: Massive Burst
     potency: 99% of max HP
+    type: Unique
     description: 'roomwide AoE'
 boss_notes:
   - note: 'Rotation:'

--- a/_potd_floorsets/091.md
+++ b/_potd_floorsets/091.md
@@ -17,13 +17,16 @@ boss_attack_damage: 685
 boss_abilities:
   - name: Abyss
     potency: 150
+    type: Magic
     description: 'instant circle AoE'
   - name: Shackle
     potency: 400
+    type: Magic
     description: 'telegraphed wide line AoE; inflicts vulnerability up (50%,
     30s)'
   - name: Word of Pain
     potency: 110
+    type: Magic
     description: 'instant roomwide(?) AoE'
   - name: Doom
     potency: n/a

--- a/_potd_floorsets/101.md
+++ b/_potd_floorsets/101.md
@@ -17,19 +17,25 @@ boss_attack_damage: 1001
 boss_abilities:
   - name: Whipcrack
     potency: 120
+    type: Physical
     description: 'instant'
   - name: Stormwind
     potency: 300
+    type: Magic
     description: 'telegraphed conal AoE'
   - name: Bombination
     potency: 300
+    type: Magic
     description: 'telegraphed pointblank AoE; inflicts slow (12s)'
   - name: Lumisphere
     potency: 300
+    type: Magic
     description: 'telegraphed circle AoE'
   - name: Aero Blast
     potency: 80
-    description: 'roomwide AoE; applies windburn (DoT potency 50, 15s)'
+    type: Physical
+    description: 'roomwide AoE; applies windburn (physical DoT potency 50,
+    15s)'
 boss_notes:
   - note: 'Rotation:'
     subnotes:

--- a/_potd_floorsets/111.md
+++ b/_potd_floorsets/111.md
@@ -17,20 +17,23 @@ boss_attack_damage: 1134
 boss_abilities:
   - name: Bloody Caress
     potency: 150
+    type: Physical
     description: 'instant'
   - name: Acid Mist
     potency: n/a
-    description: 'telegraphed pointblank AoE; inflicts poison (DoT potency 150,
-    30s)'
+    description: 'telegraphed pointblank AoE; inflicts poison (magic DoT
+    potency 150, 30s)'
   - name: Gold Dust
     potency: n/a
-    description: 'telegraphed circle AoE; inflicts poison (DoT potency 150,
-    30s)'
+    description: 'telegraphed circle AoE; inflicts poison (magic DoT potency
+    150, 30s)'
   - name: Leafstorm
     potency: 200
+    type: Physical
     description: 'roomwide AoE'
   - name: Rotten Stench
-    potency: 99999 damage
+    potency: 1100
+    type: Magic
     description: 'telegraphed wide line AoE'
 boss_notes:
   - note: 'Rotation:'
@@ -50,6 +53,7 @@ boss_notes:
   - 'If you use lust during the second Rotten Stench cast, it will last long
   enough to kill 2 sets of adds. Steel may be needed to survive long enough on
   non-tanks though'
+  - 'Rotten Stench will one-shot a DPS or healer without steel'
 boss_job_specifics:
   GNB:
     timing:

--- a/_potd_floorsets/121.md
+++ b/_potd_floorsets/121.md
@@ -17,16 +17,20 @@ boss_attack_damage: 324
 boss_abilities:
   - name: Dissever
     potency: 120
+    type: Physical
     description: 'instant'
   - name: Ball of Fire
     potency: 75
-    description: 'instant circle AoE on random player; leaves burn puddle (DoT
-    potency 450)'
+    type: Magic
+    description: 'instant circle AoE on random player; leaves burn puddle
+    (unique DoT potency 450)'
   - name: Ball of Ice
     potency: 75
+    type: Magic
     description: 'instant circle AoE on random player; leaves heavy puddle'
   - name: Fear Itself
     potency: 500
+    type: Magic
     description: 'roomwide donut AoE; inflicts hysteria (10s); must be
     inside/near boss''s target circle to avoid'
 boss_notes:

--- a/_potd_floorsets/131.md
+++ b/_potd_floorsets/131.md
@@ -17,19 +17,24 @@ boss_attack_damage: 1277
 boss_abilities:
   - name: Ancient Eruption
     potency: 400
-    description: 'telegraphed circle AoE; leaves a bleed puddle (DoT potency
-    1300)'
+    type: Magic
+    description: 'telegraphed circle AoE; leaves a bleed puddle (unique DoT
+    potency 1300)'
   - name: Entropic Flame
     potency: 1100
+    type: Magic
     description: 'telegraphed wide line AoE'
   - name: Accursed Pox
     potency: 1100?
+    type: Magic
     description: 'telegraphed circle AoE'
   - name: Scream
     potency: 300
+    type: Magic
     description: 'roomwide AoE; inflicts terror (10s) and prey'
   - name: Shadow Flare
     potency: 350
+    type: Magic
     description: 'roomwide AoE'
 boss_notes:
   - note: 'Vulnerable to resolution'

--- a/_potd_floorsets/141.md
+++ b/_potd_floorsets/141.md
@@ -17,12 +17,15 @@ boss_attack_damage: 1835
 boss_abilities:
   - name: Dark Mist
     potency: 320?
+    type: Magic
     description: 'telegraphed pointblank AoE; inflicts terror (10s)'
   - name: Void Fire IV
     potency: 350
+    type: Magic
     description: 'large telegraphed circle AoE'
   - name: Void Aero
     potency: 350?
+    type: Magic
     description: 'telegraphed wide line AoE'
   - name: Summon Darkness
     potency: n/a
@@ -35,12 +38,15 @@ boss_abilities:
     description: 'kills succubus add, absorbing its remaining HP'
   - name: Blood Rain
     potency: 350
+    type: Magic
     description: 'roomwide AoE; also hits zombie adds. Never crits'
   - name: Sweet Steel (succubus add)
     potency: 120
+    type: Physical
     description: 'instant'
   - name: Void Fire II (succubus add)
     potency: 300?
+    type: Magic
     description: 'telegraphed circle AoE'
 boss_notes:
   - note: 'Rotation:'

--- a/_potd_floorsets/151.md
+++ b/_potd_floorsets/151.md
@@ -17,13 +17,16 @@ boss_attack_damage: 2751
 boss_abilities:
   - name: Geirrothr
     potency: 65
+    type: Magic
     description: 'instant'
   - name: Hall of Sorrow
     potency: 65
-    description: 'instant large circle AoE leaving bleed puddle (DoT potency
-    100)'
+    type: Magic
+    description: 'instant large circle AoE leaving bleed puddle (unique DoT
+    potency 100)'
   - name: Valfodr
     potency: 60
+    type: Physical
     description: telegraphed charge AoE; inflicts knockback'
 boss_notes:
   - note: 'Rotation:'

--- a/_potd_floorsets/161.md
+++ b/_potd_floorsets/161.md
@@ -17,17 +17,21 @@ boss_attack_damage: 2202
 boss_abilities:
   - name: Drench
     potency: 115
+    type: Magic
     description: 'instant conal AoE'
   - name: Electrogenesis
     potency: 250
+    type: Magic
     description: 'telegraphed circle AoE'
   - name: Douse
     potency: 400?
+    type: Magic
     description: 'telegraphed pointblank AoE; leaves behind a puddle which
     grants haste and attack bonus to the boss. Standing in the puddle does NOT
     hurt you'
   - name: 'Fang''s End'
     potency: 100
+    type: Physical
     description: 'inflicts heavy (15s)'
 boss_notes:
   - note: 'Rotation:'

--- a/_potd_floorsets/171.md
+++ b/_potd_floorsets/171.md
@@ -17,22 +17,28 @@ boss_attack_damage: 3268
 boss_abilities:
   - name: Thunderbolt
     potency: 300
+    type: Magic
     description: 'telegraphed conal AoE'
   - name: Charybdis
     potency: 300?
+    type: Magic
     description: 'telegraphed circle AoE that leaves behind a tornado'
   - name: Trounce
     potency: 350?
+    type: Physical
     description: 'large telegraphed conal AoE'
   - name: Ecliptic Meteor
     potency: 80% of max HP
+    type: Unique
     description: 'roomwide AoE; medium cast time'
   - name: Maelstrom (tornado)
     potency: 130?
+    type: Magic
     description: 'telegraphed circle AoE of double the tornado''s size that
     draws players in'
   - name: Charybdis (tornado)
     potency: 500?
+    type: Magic
     description: 'used periodically against players inside the tornado'
 boss_notes:
   - note: 'Rotation:'

--- a/_potd_floorsets/181.md
+++ b/_potd_floorsets/181.md
@@ -17,22 +17,28 @@ boss_attack_damage: 4145
 boss_abilities:
   - name: Scalding Scolding
     potency: 150
+    type: Physical
     description: 'instant'
   - name: Sap
     potency: 250
+    type: Magic
     description: 'telegraphed circle AoE'
   - name: Hypothermal Combustion (Giddy Bomb)
     potency: 180?
+    type: Magic
     description: 'telegraphed pointblank AoE; inflicts deep freeze'
   - name: Hypothermal Combustion (Remedy Bomb)
     potency: 80% of max HP
+    type: Unique
     description: 'roomwide AoE; inflicts deep freeze (DoT potency 15, 5s)'
   - name: Flashthoom (Grey Bomb)
     potency: 180?
+    type: Magic
     description: 'telegraphed pointblank AoE inflicting stun (2s); also hits
     enemies, including the boss'
   - name: Massive Burst
     potency: 99% of max HP
+    type: Unique
     description: 'roomwide AoE'
 boss_notes:
   - note: 'Rotation:'


### PR DESCRIPTION
I assumed abilities shared between Palace/Nightmare and Deep Palace enemies have the same damage types, so I went ahead and filled those in (and likewise for HoH mimics).
I included a couple of ability fixes here which are directly tied to damage types; I have a few more pending which I'll wrap up into a separate PR.