### PR TITLE
More enemy ability info

### DIFF
--- a/_data/changelog.yml
+++ b/_data/changelog.yml
@@ -1,3 +1,11 @@
+- date: 2023-02-11
+  updates:
+    - 'Added more enemy ability details, courtesy of vaxherd'
+    - 'Added Deep Palace Gourmand''s Inhale ability'
+    - 'Onyx Dragon does not seem to use Chaos Breath on floor 191+'
+    - 'Fixed Chest Thump effect (5% vulnerability up, not 10%)'
+    - 'Noted that Heavenly Mukai-inu''s Ram''s/Dragon''s Voice can be
+    interrupted by impeding traps'
 - date: 2023-02-05
   updates:
     - 'Added damage types for HoH enemy abilities and filled in more HoH enemy

--- a/_hoh_081_enemies/araragi.md
+++ b/_hoh_081_enemies/araragi.md
@@ -29,8 +29,10 @@ abilities:
     potency: n/a
     description: 'instant conal AoE draw-in'
   - name: 'Moldy Sneeze'
-    description: 'telegraphed conal AoE; used immediately after draw-in; actual
-    AoE may be wider than the telegraph - get behind!'
+    potency: 800
+    type: Magic
+    description: 'telegraphed conal AoE; inflicts disease. Used immediately
+    after Inhale; actual AoE may be wider than the telegraph - get behind!'
 notes:
   - note: 'Rotation:'
     subnotes:

--- a/_hoh_081_enemies/enko.md
+++ b/_hoh_081_enemies/enko.md
@@ -20,6 +20,8 @@ abilities:
     type: Physical
     description: 'instant'
   - name: Plain Pound
+    potency: 1000
+    type: Physical
     description: 'telegraphed circle AoE'
   - name: Flex
     potency: n/a

--- a/_hoh_081_enemies/hitotsume.md
+++ b/_hoh_081_enemies/hitotsume.md
@@ -22,6 +22,8 @@ abilities:
     description: 'untelegraphed wide line AoE inflicting paralysis - get to the
     side or behind'
   - name: '100-tonze Swing'
+    potency: 1000
+    type: Physical
     description: 'untelegraphed pointblank AoE inflicting knockback - get away;
     can also be LoSed'
 job_specifics:

--- a/_hoh_081_enemies/mukai_inu.md
+++ b/_hoh_081_enemies/mukai_inu.md
@@ -43,6 +43,8 @@ notes:
   - 'These mostly just spam abilities, doing very little auto-attack damage'
   - 'Try to stand behind it during Dragon''s Voice and Breath attacks to delay
   its next auto-attack'
+  - 'Voice and Breath abilities are all treated as spells, so an impeding trap
+  can interrupt one in an emergency'
 job_specifics:
   DRK:
     difficulty: Easy

--- a/_hoh_081_enemies/rakshasa.md
+++ b/_hoh_081_enemies/rakshasa.md
@@ -32,6 +32,8 @@ abilities:
     type: Physical
     description: 'untelegraphed conal AoE - get away or behind'
   - name: Fireball
+    potency: 400
+    type: Magic
     description: 'telegraphed circle AoE'
 job_specifics:
   DRK:

--- a/_hoh_081_enemies/rowan.md
+++ b/_hoh_081_enemies/rowan.md
@@ -29,7 +29,7 @@ abilities:
     potency: 30
     type: Magic
     description: 'huge 1.5 room instant AoE that inflicts stacking physical
-    vulnerability up (10% per stack, max 8 stacks, 8s). Only used out of combat
+    vulnerability up (5% per stack, max 8 stacks, 8s). Only used out of combat
     during Ripe Banana'
 notes:
   - 'Hits hard, and doesn''t stop to use abilities so the damage is constant'

--- a/_hoh_091_enemies/kubinashi.md
+++ b/_hoh_091_enemies/kubinashi.md
@@ -17,13 +17,20 @@ vulnerabilities:
   stun: false
 abilities:
   - name: 'Iron Justice'
-    description: 'Cleave'
+    potency: 120
+    type: Physical
+    description: 'cleave'
   - name: 'Drainstrikes'
     potency: n/a
-    description: 'grants drainstrikes (30s) - attacks drain HP from target,
-    healing self'
+    description: 'grants drainstrikes (3m), causing auto-attacks to heal self
+    for 28.6% of damage dealt'
   - name: 'Cloudcover'
     description: 'telegraphed circle AoE; can be interrupted'
+  - name: '?'
+    description: 'grants stacking damage up (+10% per stack)'
+  - name: 'Black Nebula'
+    description: 'untelegraphed enrage; used about 1 minute after pull; can be
+    interrupted'
 notes:
   - 'Each time it grows, it gains a stacking damage up buff'
   - note: 'Pattern:'

--- a/_hoh_floorsets/081.md
+++ b/_hoh_floorsets/081.md
@@ -15,18 +15,29 @@ boss_hp: 791333
 boss_attack_damage: 3787
 boss_abilities:
   - name: Burning Rave
+    potency: 1000
+    type: Magic
     description: 'telegraphed circle AoE'
   - name: Knuckle Press
-    description: 'telegraphed pointblank AoE'
+    potency: 1500
+    type: Physical
+    description: 'telegraphed pointblank AoE; inflicts knockback'
   - name: Aura Cannon
+    potency: 1200
+    type: Magic
     description: 'telegraphed wide line AoE'
   - name: Ancient Quaga
     potency: 50% of max HP
     type: Unique
     description: 'roomwide AoE'
   - name: Meteor Impact
+    potency: 100-2000
     type: Magic
     description: 'delayed proximity AoE'
+  - name: Subduction (orb adds)
+    potency: 100
+    type: Magic
+    description: 'instant pointblank AoE; inflicts heavy (30s) and knockback'
 boss_notes:
   - note: 'Rotation before 85%:'
     subnotes:
@@ -37,7 +48,7 @@ boss_notes:
     subnotes:
       - 'Ancient Quaga'
       - 'Meteor Impact - drops proximity marker under Onra; several black orbs
-      also spawn around the room and pulse pointblank AoEs that cause heavy'
+      also spawn around the room and pulse pointblank AoEs that inflict heavy'
       - 'Aura Cannon'
       - 'Burning Rave - meteor drops on proximity marker, and black orbs
       disappear roughly when this cast starts'

--- a/_potd_051_enemies/arch_demon.md
+++ b/_potd_051_enemies/arch_demon.md
@@ -20,7 +20,7 @@ abilities:
   - name: Abyssal Transfixion
     potency: 130
     type: Physical
-    description: 'instant'
+    description: 'instant ranged attack'
   - name: Abyssal Swing
     potency: 300
     type: Physical

--- a/_potd_051_enemies/gremlin.md
+++ b/_potd_051_enemies/gremlin.md
@@ -18,7 +18,7 @@ vulnerabilities:
 abilities:
   - name: Bad Mouth
     potency: n/a
-    description: 'instant; inflicts vulnerability up (25%, 10s)'
+    description: 'inflicts vulnerability up (25%, 10s) on random player'
   - name: Fire II
     potency: 300
     type: Magic

--- a/_potd_091_enemies/gourmand.md
+++ b/_potd_091_enemies/gourmand.md
@@ -21,7 +21,8 @@ abilities:
     type: Physical
     description: 'instant'
   - name: 'Dirty Sneeze'
-    potency: 130?
+    potency: 100
+    type: Magic
     description: 'instant; only used against lower-enmity party members (not
     used against solo adventurers)'
 job_specifics:

--- a/_potd_131_enemies/ahriman.md
+++ b/_potd_131_enemies/ahriman.md
@@ -20,10 +20,11 @@ vulnerabilities:
 abilities:
   - name: Level 5 Petrify
     potency: n/a
-    description: 'untelegraphed conal AoE inflicting petrify (15s) - get behind
-    or get away'
+    description: 'untelegraphed conal AoE on random player inflicting petrify
+    (15s) - get behind or get away'
 notes:
   - 'Can be slowed if transfigured via Pomander of Witching'
+  - 'Stay close when in parties to avoid being caught out by random targeting'
 job_specifics:
   SGE:
     difficulty: Medium

--- a/_potd_131_enemies/gourmand.md
+++ b/_potd_131_enemies/gourmand.md
@@ -21,6 +21,15 @@ abilities:
     potency: 130
     type: Physical
     description: 'instant'
+  - name: Inhale
+    potency: n/a
+    description: 'instant conal AoE draw-in; inflicts stun (2s). Only used
+    against lower-enmity party members (not used against solo adventurers)'
+  - name: Dirty Sneeze
+    potency: 100
+    type: Magic
+    description: 'instant conal AoE; used immediately after Inhale on the same
+    target'
 job_specifics:
   SGE:
     difficulty: Easy

--- a/_potd_131_enemies/taurus.md
+++ b/_potd_131_enemies/taurus.md
@@ -22,8 +22,8 @@ abilities:
     description: 'instant'
   - name: Voidblood
     potency: n/a
-    description: 'telegraphed circle AoE that inflicts Voidblood (increases
-    damage taken); not used vs. solo adventurers'
+    description: 'telegraphed circle AoE that inflicts Voidblood (damage taken
+    +10%, 30s); not used against solo adventurers'
 job_specifics:
   SGE:
     difficulty: Easy

--- a/_potd_151_enemies/abaia.md
+++ b/_potd_151_enemies/abaia.md
@@ -20,7 +20,8 @@ abilities:
   - name: Terror Eye
     potency: 300
     type: Magic
-    description: 'telegraphed circle AoE; also used out of combat'
+    description: 'telegraphed circle AoE; can be interrupted. Also used out of
+    combat'
   - name: 'Triumphant Roar'
     potency: n/a
     description: 'grants physical damage up (80%, 30s) to self; used 47 seconds

--- a/_potd_151_enemies/arch_demon.md
+++ b/_potd_151_enemies/arch_demon.md
@@ -25,7 +25,7 @@ abilities:
   - name: Abyssal Transfixion
     potency: 130
     type: Physical
-    description: 'instant; inflicts paralysis (30s)'
+    description: 'ranged attack on random player; inflicts paralysis (30s)'
 notes:
   - 'If there are several, you may want to pull them in quick succession to
     take advantage of diminishing returns on paralysis'

--- a/_potd_151_enemies/gremlin.md
+++ b/_potd_151_enemies/gremlin.md
@@ -18,7 +18,7 @@ vulnerabilities:
 abilities:
   - name: Bad Mouth
     potency: n/a
-    description: 'instant; inflicts vulnerability up (25%, 10s)'
+    description: 'inflicts vulnerability up (25%, 10s) on random player'
   - name: Fire II
     potency: 300
     type: Magic

--- a/_potd_151_enemies/marolith.md
+++ b/_potd_151_enemies/marolith.md
@@ -24,7 +24,7 @@ abilities:
   - name: Isle Drop
     potency: 300
     type: Physical
-    description: 'telegraphed circle AoE; inflicts stun (5s)'
+    description: 'telegraphed circle AoE on random player; inflicts stun (5s)'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_161_enemies/pteranodon.md
+++ b/_potd_161_enemies/pteranodon.md
@@ -20,7 +20,7 @@ abilities:
   - name: Lightning Bolt
     potency: 300
     type: Magic
-    description: 'telegraphed circle AoE'
+    description: 'telegraphed circle AoE on random player'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_161_enemies/tursus.md
+++ b/_potd_161_enemies/tursus.md
@@ -25,7 +25,7 @@ abilities:
   - name: Ice Dispenser
     potency: 130
     type: Magic
-    description: 'instant circle AoE; inflicts slow (15s)'
+    description: 'instant circle AoE on random player; inflicts slow (15s)'
 notes:
   - 'If there are several, you may want to pull them in quick succession to
     take advantage of diminishing returns on slow'

--- a/_potd_171_enemies/sasquatch.md
+++ b/_potd_171_enemies/sasquatch.md
@@ -29,7 +29,7 @@ abilities:
     potency: 30
     type: Magic
     description: 'huge 1.5 room instant AoE that inflicts stacking physical
-    vulnerability up (10% per stack, max 5 stacks, 8s). Only used out of combat
+    vulnerability up (5% per stack, max 8 stacks, 8s). Only used out of combat
     during Ripe Banana'
 notes:
   - Hits VERY hard

--- a/_potd_171_enemies/wolf.md
+++ b/_potd_171_enemies/wolf.md
@@ -19,8 +19,8 @@ abilities:
   - name: Sanguine Bite
     potency: 130
     type: Physical
-    description: 'instant; absorbs 100% of damage dealt; inflicts frostbite
-    (physical DoT potency 50, 12s)'
+    description: 'instant conal AoE; absorbs 100% of damage dealt; inflicts
+    frostbite (physical DoT potency 50, 12s)'
 notes:
   - Hits pretty hard
   - 'Doesn''t stop to use any abilities, so the damage is constant'

--- a/_potd_181_enemies/claw.md
+++ b/_potd_181_enemies/claw.md
@@ -28,7 +28,7 @@ abilities:
   - name: Tail Screw
     potency: 150
     type: Magic
-    description: 'inflicts slow (20s); can be outranged'
+    description: 'untelegraphed pointblank AoE; inflicts slow (20s)'
 notes:
   - 'Does a draw-in that inflicts Prey status followed by Impale. Knockback
     immunity does not work, but draw-in will not work on floors with knockback

--- a/_potd_181_enemies/wamouracampa.md
+++ b/_potd_181_enemies/wamouracampa.md
@@ -19,7 +19,7 @@ abilities:
   - name: Cannonball
     potency: 130
     type: Magic
-    description: 'instant ranged attack'
+    description: 'instant ranged attack on random player'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_181_enemies/worm.md
+++ b/_potd_181_enemies/worm.md
@@ -19,9 +19,9 @@ abilities:
   - name: Sand Pillar
     potency: 120
     type: Magic
-    description: 'instant circle AoE. Also used out of combat, with potency 75;
-    be very careful if there are several worms nearby, as getting hit by a few
-    of these at once could kill you'
+    description: 'instant circle AoE on random player. Also used out of combat,
+    with potency 75; be very careful if there are several worms nearby, as
+    getting hit by a few of these at once could kill you'
   - name: Bottomless Desert
     potency: 20
     description: 'quick huge pointblank AoE; draws players in. Knockback

--- a/_potd_191_enemies/bicephalus.md
+++ b/_potd_191_enemies/bicephalus.md
@@ -20,7 +20,7 @@ abilities:
   - name: Glass Punch
     potency: 150
     type: Physical
-    description: 'instant'
+    description: 'instant conal AoE'
   - name: Catapult
     description: 'telegraphed circle AoE'
 job_specifics:

--- a/_potd_191_enemies/dragon.md
+++ b/_potd_191_enemies/dragon.md
@@ -21,10 +21,7 @@ abilities:
     description: conal gaze AoE - look away, get behind, or get away
   - name: Miasma Breath
     potency: 300
-    description: telegraphed conal AoE; inflicts disease
-  - name: 'Chaos Breath (?)'
-    description: 'large telegraphed conal AoE; not used against solo
-    adventurers'
+    description: telegraphed conal AoE; inflicts disease (15s)
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_191_enemies/fachan.md
+++ b/_potd_191_enemies/fachan.md
@@ -21,12 +21,13 @@ vulnerabilities:
 abilities:
   - name: Level 5 Death
     potency: n/a
-    description: 'untelegraphed conal AoE causing instant death - get behind,
-    or get away'
+    description: 'untelegraphed conal AoE on random player inflicting instant
+    death - get behind or get away'
 notes:
   - 'Caster - kiting doesn''t help to mitigate damage'
   - 'Can be slowed if transfigured via Pomander of Witching'
   - 'Interrupts spell casts very often'
+  - 'Stay close when in parties to avoid being caught out by random targeting'
 job_specifics:
   GNB:
     difficulty: Easy

--- a/_potd_191_enemies/gourmand.md
+++ b/_potd_191_enemies/gourmand.md
@@ -20,10 +20,15 @@ abilities:
     potency: 130
     type: Physical
     description: 'instant'
-  - name: 'Dirty Sneeze'
-    potency: 130?
-    description: 'instant; only used against lower-enmity party members (not
-    used against solo adventurers)'
+  - name: Inhale
+    potency: n/a
+    description: 'instant conal AoE draw-in; inflicts stun (2s). Only used
+    against lower-enmity party members (not used against solo adventurers)'
+  - name: Dirty Sneeze
+    potency: 70
+    type: Magic
+    description: 'instant conal AoE; used immediately after Inhale on the same
+    target'
 job_specifics:
   GNB:
     difficulty: Medium

--- a/_potd_floorsets/141.md
+++ b/_potd_floorsets/141.md
@@ -22,7 +22,7 @@ boss_abilities:
   - name: Void Fire IV
     potency: 350
     type: Magic
-    description: 'large telegraphed circle AoE'
+    description: 'large telegraphed circle AoE on random player'
   - name: Void Aero
     potency: 350
     type: Magic
@@ -77,6 +77,8 @@ boss_notes:
     likely better for others to kill them. They have pretty low HP'
   - 'If you''re not killing the succubus add, it''s worth putting DoTs on it
     anyway'
+  - 'In party play, Summon Darkness (Gargoyle/Vodoriga) summons one add for
+    each party member'
 boss_job_specifics:
   GNB:
     timing:


### PR DESCRIPTION
a.k.a. Somehow Further Deep Dungeon Adventures

I suspect PotD Garms are also susceptible to silence, but 181+ is a bit of a long way to go just to spend a Sight on testing...
(Incidentally, I also noticed a very high rate of impeding traps in HoH 81-83, >60% of 40 traps checked. Maybe intentional?)

Backstory on the "28.6%" drain ratio for Kubinashi - I'd noticed previously that HoH wolves drained slightly less than 100% of their Sanguine Bite damage, and when I checked, the ratio was always 95.5% rounded to the nearest 0.1%. I checked one of Angelus's VODs for a Kubinashi fight (as GNB) and that one turned out to be always 28.6%, which happens to be 95.5% of 30% (where 30% is the PotD Dullahan drainstrike ratio). When I went back and checked pre-EW logs, the wolf drain ratio was around 88%, which makes me think there's some player or enemy stat being incorrectly applied to reduce the heal amount, and because of the EW stat squish, the reduction amount is now smaller. Which is all a long-winded way of saying "yes, it really is that precise value" :)