### PR TITLE
Dread beast stats/abilities

### DIFF
--- a/_data/changelog.yml
+++ b/_data/changelog.yml
@@ -1,5 +1,8 @@
 - date: 2023-03-21
   updates:
+    - 'Added EO dread beast details, courtesy of vaxherd'
+- date: 2023-03-21
+  updates:
     - 'Added dread beasts to all EO floorsets'
     - 'Added more EO enemy and floorset details, some courtesy of vaxherd'
 - date: 2023-03-20

--- a/_eo_001_enemies/demi-cochma.md
+++ b/_eo_001_enemies/demi-cochma.md
@@ -5,6 +5,8 @@ image: ../demi-cochma.png
 start_floor: 1
 end_floor: 9
 agro: Sight
+extreme_hp: 415716
+extreme_attack_damage: 34000
 attack_type: Physical
 vulnerabilities:
   bind: unknown
@@ -13,6 +15,8 @@ vulnerabilities:
   slow: unknown
   stun: unknown
 gallery_only: true
+extreme_attack_damage: 33000
+attack_type: Physical
 notes:
   - Dread beast
 ---

--- a/_eo_001_enemies/demi-cochma.md
+++ b/_eo_001_enemies/demi-cochma.md
@@ -15,7 +15,6 @@ vulnerabilities:
   slow: unknown
   stun: unknown
 gallery_only: true
-extreme_attack_damage: 33000
 attack_type: Physical
 notes:
   - Dread beast

--- a/_eo_001_enemies/lamia_queen.md
+++ b/_eo_001_enemies/lamia_queen.md
@@ -8,21 +8,25 @@ attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
-  sleep: unknown
+  sleep: false
   slow: unknown
   stun: unknown
 gallery_only: true
+extreme_hp: 415716
+attack_type: Physical
 abilities:
   - name: "Circle of Flame (?)"
     potency: 80
     type: Magic
-    description: "instant circle AoE"
+    description: "instant circle AoE; also grants permanent stacking HP
+    regeneration to self"
   - name: Circle Blade
     description: "telegraphed pointblank AoE"
   - name: "Petrifaction"
     potency: n/a
     description: "huge 360 degree gaze inflicting stone curse; also affects
-    enemies. Used at critical health (such as after Storms)"
+    enemies. Used at critical health (such as after Storms or landmine)"
 notes:
   - Dread beast
+  - Regenerates a small amount of HP every tick while in combat
 ---

--- a/_eo_001_enemies/meracydian_clone.md
+++ b/_eo_001_enemies/meracydian_clone.md
@@ -4,22 +4,27 @@ nickname: Meracydian Clone
 image: ../meracydian_clone.png
 start_floor: 1
 end_floor: 9
-agro: 'Sight'
+agro: Sight
 extreme_hp: 415716
-extreme_attack_damage: 26000
+extreme_attack_damage: 34000
 attack_type: Physical
 vulnerabilities:
-  bind: '?'
-  heavy: '?'
-  sleep: '?'
-  slow: '?'
-  stun: '?'
+  bind: unknown
+  heavy: unknown
+  sleep: false
+  slow: unknown
+  stun: unknown
 gallery_only: true
-abilities:
-  - name: 'Hard Thrust (?)'
+abilities: 
+  - name: "Hard Thrust (?)"
     potency: 90
     type: Physical
-    description: 'instant'
+    description: "instant"
+  - name: Berserk
+    potency: n/a
+    description: "probably grants damage up to self; can be interrupted"
+  - name: Allagan Meteor
+    description: "huge (20y) pointblank AoE enrage; used below 40% HP"
 notes:
   - Dread beast
 ---

--- a/_eo_011_enemies/demi-cochma.md
+++ b/_eo_011_enemies/demi-cochma.md
@@ -5,6 +5,7 @@ image: ../demi-cochma.png
 start_floor: 11
 end_floor: 19
 agro: Sight
+extreme_hp: 631104
 attack_type: Physical
 vulnerabilities:
   bind: unknown

--- a/_eo_011_enemies/lamia_queen.md
+++ b/_eo_011_enemies/lamia_queen.md
@@ -8,15 +8,19 @@ attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
-  sleep: unknown
+  sleep: false
   slow: unknown
   stun: unknown
 gallery_only: true
+extreme_hp: 631104
+extreme_attack_damage: 32000
+attack_type: Physical
 abilities:
   - name: "Circle of Flame (?)"
     potency: 80
     type: Magic
-    description: "instant circle AoE"
+    description: "instant circle AoE; also grants permanent stacking HP
+    regeneration to self"
   - name: Circle Blade
     description: "telegraphed pointblank AoE"
   - name: "Petrifaction"
@@ -25,4 +29,5 @@ abilities:
     enemies. Used at critical health (such as after Storms)"
 notes:
   - Dread beast
+  - Regenerates a small amount of HP every tick while in combat
 ---

--- a/_eo_011_enemies/meracydian_clone.md
+++ b/_eo_011_enemies/meracydian_clone.md
@@ -4,20 +4,26 @@ nickname: Meracydian Clone
 image: ../meracydian_clone.png
 start_floor: 11
 end_floor: 19
-agro: 'Sight'
+agro: Sight
+extreme_hp: 631104
 attack_type: Physical
 vulnerabilities:
-  bind: '?'
-  heavy: '?'
-  sleep: '?'
-  slow: '?'
-  stun: '?'
+  bind: unknown
+  heavy: unknown
+  sleep: false
+  slow: unknown
+  stun: unknown
 gallery_only: true
-abilities:
-  - name: 'Hard Thrust (?)'
+abilities: 
+  - name: "Hard Thrust (?)"
     potency: 90
     type: Physical
-    description: 'instant'
+    description: "instant"
+  - name: Berserk
+    potency: n/a
+    description: "probably grants damage up to self; can be interrupted"
+  - name: Allagan Meteor
+    description: "huge (20y) pointblank AoE enrage; used below 40% HP"
 notes:
   - Dread beast
 ---

--- a/_eo_021_enemies/demi-cochma.md
+++ b/_eo_021_enemies/demi-cochma.md
@@ -5,6 +5,7 @@ image: ../demi-cochma.png
 start_floor: 21
 end_floor: 29
 agro: Sight
+extreme_hp: 703072
 attack_type: Physical
 vulnerabilities:
   bind: unknown

--- a/_eo_021_enemies/lamia_queen.md
+++ b/_eo_021_enemies/lamia_queen.md
@@ -8,15 +8,19 @@ attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
-  sleep: unknown
+  sleep: false
   slow: unknown
   stun: unknown
 gallery_only: true
+extreme_hp: 703072
+extreme_attack_damage: 37000
+attack_type: Physical
 abilities:
   - name: "Circle of Flame (?)"
     potency: 80
     type: Magic
-    description: "instant circle AoE"
+    description: "instant circle AoE; also grants permanent stacking HP
+    regeneration (~1700 HP/tick per stack) to self"
   - name: Circle Blade
     description: "telegraphed pointblank AoE"
   - name: "Petrifaction"

--- a/_eo_021_enemies/meracydian_clone.md
+++ b/_eo_021_enemies/meracydian_clone.md
@@ -4,20 +4,26 @@ nickname: Meracydian Clone
 image: ../meracydian_clone.png
 start_floor: 21
 end_floor: 29
-agro: 'Sight'
+agro: Sight
+extreme_hp: 703072
 attack_type: Physical
 vulnerabilities:
-  bind: '?'
-  heavy: '?'
-  sleep: '?'
-  slow: '?'
-  stun: '?'
+  bind: unknown
+  heavy: unknown
+  sleep: false
+  slow: unknown
+  stun: unknown
 gallery_only: true
-abilities:
-  - name: 'Hard Thrust (?)'
+abilities: 
+  - name: "Hard Thrust (?)"
     potency: 90
     type: Physical
-    description: 'instant'
+    description: "instant"
+  - name: Berserk
+    potency: n/a
+    description: "probably grants damage up to self; can be interrupted"
+  - name: Allagan Meteor
+    description: "huge (20y) pointblank AoE enrage; used below 40% HP"
 notes:
   - Dread beast
 ---

--- a/_eo_031_enemies/demi-cochma.md
+++ b/_eo_031_enemies/demi-cochma.md
@@ -5,6 +5,7 @@ image: ../demi-cochma.png
 start_floor: 31
 end_floor: 39
 agro: Sight
+extreme_hp: 829016
 attack_type: Physical
 vulnerabilities:
   bind: unknown

--- a/_eo_031_enemies/lamia_queen.md
+++ b/_eo_031_enemies/lamia_queen.md
@@ -8,15 +8,18 @@ attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
-  sleep: unknown
+  sleep: false
   slow: unknown
   stun: unknown
 gallery_only: true
+extreme_hp: 829016
+attack_type: Physical
 abilities:
   - name: "Circle of Flame (?)"
     potency: 80
     type: Magic
-    description: "instant circle AoE"
+    description: "instant circle AoE; also grants permanent stacking HP
+    regeneration to self"
   - name: Circle Blade
     description: "telegraphed pointblank AoE"
   - name: "Petrifaction"

--- a/_eo_031_enemies/meracydian_clone.md
+++ b/_eo_031_enemies/meracydian_clone.md
@@ -4,20 +4,26 @@ nickname: Meracydian Clone
 image: ../meracydian_clone.png
 start_floor: 31
 end_floor: 39
-agro: 'Sight'
+agro: Sight
+extreme_hp: 829016
 attack_type: Physical
 vulnerabilities:
-  bind: '?'
-  heavy: '?'
-  sleep: '?'
-  slow: '?'
-  stun: '?'
+  bind: unknown
+  heavy: unknown
+  sleep: false
+  slow: unknown
+  stun: unknown
 gallery_only: true
-abilities:
-  - name: 'Hard Thrust (?)'
+abilities: 
+  - name: "Hard Thrust (?)"
     potency: 90
     type: Physical
-    description: 'instant'
+    description: "instant"
+  - name: Berserk
+    potency: n/a
+    description: "probably grants damage up to self; can be interrupted"
+  - name: Allagan Meteor
+    description: "huge (20y) pointblank AoE enrage; used below 40% HP"
 notes:
   - Dread beast
 ---

--- a/_eo_041_enemies/demi-cochma.md
+++ b/_eo_041_enemies/demi-cochma.md
@@ -5,6 +5,7 @@ image: ../demi-cochma.png
 start_floor: 41
 end_floor: 49
 agro: Sight
+extreme_hp: 900984
 attack_type: Physical
 vulnerabilities:
   bind: unknown

--- a/_eo_041_enemies/lamia_queen.md
+++ b/_eo_041_enemies/lamia_queen.md
@@ -8,15 +8,18 @@ attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
-  sleep: unknown
+  sleep: false
   slow: unknown
   stun: unknown
 gallery_only: true
+extreme_hp: 900984
+attack_type: Physical
 abilities:
   - name: "Circle of Flame (?)"
     potency: 80
     type: Magic
-    description: "instant circle AoE"
+    description: "instant circle AoE; also grants permanent stacking HP
+    regeneration to self"
   - name: Circle Blade
     description: "telegraphed pointblank AoE"
   - name: "Petrifaction"

--- a/_eo_041_enemies/meracydian_clone.md
+++ b/_eo_041_enemies/meracydian_clone.md
@@ -4,20 +4,27 @@ nickname: Meracydian Clone
 image: ../meracydian_clone.png
 start_floor: 41
 end_floor: 49
-agro: 'Sight'
+agro: Sight
+extreme_hp: 900984
+extreme_attack_damage: 65000
 attack_type: Physical
 vulnerabilities:
-  bind: '?'
-  heavy: '?'
-  sleep: '?'
-  slow: '?'
-  stun: '?'
+  bind: unknown
+  heavy: unknown
+  sleep: false
+  slow: unknown
+  stun: unknown
 gallery_only: true
-abilities:
-  - name: 'Hard Thrust (?)'
+abilities: 
+  - name: "Hard Thrust (?)"
     potency: 90
     type: Physical
-    description: 'instant'
+    description: "instant"
+  - name: Berserk
+    potency: n/a
+    description: "probably grants damage up to self; can be interrupted"
+  - name: Allagan Meteor
+    description: "huge (20y) pointblank AoE enrage; used below 40% HP"
 notes:
   - Dread beast
 ---

--- a/_eo_051_enemies/lamia_queen.md
+++ b/_eo_051_enemies/lamia_queen.md
@@ -8,15 +8,17 @@ attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
-  sleep: unknown
+  sleep: false
   slow: unknown
   stun: unknown
 gallery_only: true
+attack_type: Physical
 abilities:
   - name: "Circle of Flame (?)"
     potency: 80
     type: Magic
-    description: "instant circle AoE"
+    description: "instant circle AoE; also grants permanent stacking HP
+    regeneration to self"
   - name: Circle Blade
     description: "telegraphed pointblank AoE"
   - name: "Petrifaction"

--- a/_eo_051_enemies/meracydian_clone.md
+++ b/_eo_051_enemies/meracydian_clone.md
@@ -4,20 +4,25 @@ nickname: Meracydian Clone
 image: ../meracydian_clone.png
 start_floor: 51
 end_floor: 59
-agro: 'Sight'
+agro: Sight
 attack_type: Physical
 vulnerabilities:
-  bind: '?'
-  heavy: '?'
-  sleep: '?'
-  slow: '?'
-  stun: '?'
+  bind: unknown
+  heavy: unknown
+  sleep: false
+  slow: unknown
+  stun: unknown
 gallery_only: true
-abilities:
-  - name: 'Hard Thrust (?)'
+abilities: 
+  - name: "Hard Thrust (?)"
     potency: 90
     type: Physical
-    description: 'instant'
+    description: "instant"
+  - name: Berserk
+    potency: n/a
+    description: "probably grants damage up to self; can be interrupted"
+  - name: Allagan Meteor
+    description: "huge (20y) pointblank AoE enrage; used below 40% HP"
 notes:
   - Dread beast
 ---

--- a/_eo_061_enemies/lamia_queen.md
+++ b/_eo_061_enemies/lamia_queen.md
@@ -8,21 +8,23 @@ attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
-  sleep: unknown
+  sleep: false
   slow: unknown
   stun: unknown
 gallery_only: true
+attack_type: Physical
 abilities:
   - name: "Circle of Flame (?)"
     potency: 80
     type: Magic
-    description: "instant circle AoE"
+    description: "instant circle AoE; also grants permanent stacking HP
+    regeneration to self"
   - name: Circle Blade
     description: "telegraphed pointblank AoE"
   - name: "Petrifaction"
     potency: n/a
     description: "huge 360 degree gaze inflicting stone curse; also affects
-    enemies. Used at critical health (such as after Storms)"
+    enemies. Used at critical health (such as after Storms or landmine)"
 notes:
   - Dread beast
 ---

--- a/_eo_061_enemies/meracydian_clone.md
+++ b/_eo_061_enemies/meracydian_clone.md
@@ -4,20 +4,25 @@ nickname: Meracydian Clone
 image: ../meracydian_clone.png
 start_floor: 61
 end_floor: 69
-agro: 'Sight'
+agro: Sight
 attack_type: Physical
 vulnerabilities:
-  bind: '?'
-  heavy: '?'
-  sleep: '?'
-  slow: '?'
-  stun: '?'
+  bind: unknown
+  heavy: unknown
+  sleep: false
+  slow: unknown
+  stun: unknown
 gallery_only: true
-abilities:
-  - name: 'Hard Thrust (?)'
+abilities: 
+  - name: "Hard Thrust (?)"
     potency: 90
     type: Physical
-    description: 'instant'
+    description: "instant"
+  - name: Berserk
+    potency: n/a
+    description: "probably grants damage up to self; can be interrupted"
+  - name: Allagan Meteor
+    description: "huge (20y) pointblank AoE enrage; used below 40% HP"
 notes:
   - Dread beast
 ---

--- a/_eo_071_enemies/lamia_queen.md
+++ b/_eo_071_enemies/lamia_queen.md
@@ -8,21 +8,23 @@ attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
-  sleep: unknown
+  sleep: false
   slow: unknown
   stun: unknown
 gallery_only: true
+attack_type: Physical
 abilities:
   - name: "Circle of Flame (?)"
     potency: 80
     type: Magic
-    description: "instant circle AoE"
+    description: "instant circle AoE; also grants permanent stacking HP
+    regeneration to self"
   - name: Circle Blade
     description: "telegraphed pointblank AoE"
   - name: "Petrifaction"
     potency: n/a
     description: "huge 360 degree gaze inflicting stone curse; also affects
-    enemies. Used at critical health (such as after Storms)"
+    enemies. Used at critical health (such as after Storms or landmine)"
 notes:
   - Dread beast
 ---

--- a/_eo_071_enemies/meracydian_clone.md
+++ b/_eo_071_enemies/meracydian_clone.md
@@ -4,20 +4,25 @@ nickname: Meracydian Clone
 image: ../meracydian_clone.png
 start_floor: 71
 end_floor: 79
-agro: 'Sight'
+agro: Sight
 attack_type: Physical
 vulnerabilities:
-  bind: '?'
-  heavy: '?'
-  sleep: '?'
-  slow: '?'
-  stun: '?'
+  bind: unknown
+  heavy: unknown
+  sleep: false
+  slow: unknown
+  stun: unknown
 gallery_only: true
-abilities:
-  - name: 'Hard Thrust (?)'
+abilities: 
+  - name: "Hard Thrust (?)"
     potency: 90
     type: Physical
-    description: 'instant'
+    description: "instant"
+  - name: Berserk
+    potency: n/a
+    description: "probably grants damage up to self; can be interrupted"
+  - name: Allagan Meteor
+    description: "huge (20y) pointblank AoE enrage; used below 40% HP"
 notes:
   - Dread beast
 ---

--- a/_eo_071_enemies/thunderbeast.md
+++ b/_eo_071_enemies/thunderbeast.md
@@ -18,7 +18,7 @@ abilities:
     description: "untelegraphed pointblank AoE; pauses in place for a moment
     before using this - get away!"
   - name: "Spark (?)"
-    description: "untelegraphed huge donut(?) AoE; only used if someone is far"
+    description: "untelegraphed huge donut AoE; only used if someone is far"
 notes:
   - "It can help to keep rotating around the enemy, so you can more easily tell
   when he's using abilities"

--- a/_eo_081_enemies/lamia_queen.md
+++ b/_eo_081_enemies/lamia_queen.md
@@ -8,21 +8,23 @@ attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
-  sleep: unknown
+  sleep: false
   slow: unknown
   stun: unknown
 gallery_only: true
+attack_type: Physical
 abilities:
   - name: "Circle of Flame (?)"
     potency: 80
     type: Magic
-    description: "instant circle AoE"
+    description: "instant circle AoE; also grants permanent stacking HP
+    regeneration to self"
   - name: Circle Blade
     description: "telegraphed pointblank AoE"
   - name: "Petrifaction"
     potency: n/a
     description: "huge 360 degree gaze inflicting stone curse; also affects
-    enemies. Used at critical health (such as after Storms)"
+    enemies. Used at critical health (such as after Storms or landmine)"
 notes:
   - Dread beast
 ---

--- a/_eo_081_enemies/meracydian_clone.md
+++ b/_eo_081_enemies/meracydian_clone.md
@@ -4,20 +4,25 @@ nickname: Meracydian Clone
 image: ../meracydian_clone.png
 start_floor: 81
 end_floor: 89
-agro: 'Sight'
+agro: Sight
 attack_type: Physical
 vulnerabilities:
-  bind: '?'
-  heavy: '?'
-  sleep: '?'
-  slow: '?'
-  stun: '?'
+  bind: unknown
+  heavy: unknown
+  sleep: false
+  slow: unknown
+  stun: unknown
 gallery_only: true
 abilities:
-  - name: 'Hard Thrust (?)'
+  - name: "Hard Thrust (?)"
     potency: 90
     type: Physical
-    description: 'instant'
+    description: "instant"
+  - name: Berserk
+    potency: n/a
+    description: "probably grants damage up to self; can be interrupted"
+  - name: Allagan Meteor
+    description: "huge (20y) pointblank AoE enrage; used below 40% HP"
 notes:
   - Dread beast
 ---

--- a/_eo_091_enemies/lamia_queen.md
+++ b/_eo_091_enemies/lamia_queen.md
@@ -8,21 +8,23 @@ attack_type: Physical
 vulnerabilities:
   bind: unknown
   heavy: unknown
-  sleep: unknown
+  sleep: false
   slow: unknown
   stun: unknown
 gallery_only: true
+attack_type: Physical
 abilities:
   - name: "Circle of Flame (?)"
     potency: 80
     type: Magic
-    description: "instant circle AoE"
+    description: "instant circle AoE; also grants permanent stacking HP
+    regeneration to self"
   - name: Circle Blade
     description: "telegraphed pointblank AoE"
   - name: "Petrifaction"
     potency: n/a
     description: "huge 360 degree gaze inflicting stone curse; also affects
-    enemies. Used at critical health (such as after Storms)"
+    enemies. Used at critical health (such as after Storms or landmine)"
 notes:
   - Dread beast
 ---

--- a/_eo_091_enemies/meracydian_clone.md
+++ b/_eo_091_enemies/meracydian_clone.md
@@ -4,20 +4,25 @@ nickname: Meracydian Clone
 image: ../meracydian_clone.png
 start_floor: 91
 end_floor: 98
-agro: 'Sight'
+agro: Sight
 attack_type: Physical
 vulnerabilities:
-  bind: '?'
-  heavy: '?'
-  sleep: '?'
-  slow: '?'
-  stun: '?'
+  bind: unknown
+  heavy: unknown
+  sleep: false
+  slow: unknown
+  stun: unknown
 gallery_only: true
 abilities:
-  - name: 'Hard Thrust (?)'
+  - name: "Hard Thrust (?)"
     potency: 90
     type: Physical
-    description: 'instant'
+    description: "instant"
+  - name: Berserk
+    potency: n/a
+    description: "probably grants damage up to self; can be interrupted"
+  - name: Allagan Meteor
+    description: "huge (20y) pointblank AoE enrage; used below 40% HP"
 notes:
   - Dread beast
 ---


### PR DESCRIPTION
HP directly confirmed for Demi-Cochma 1/21/41, Lamia Queen 11/21/31, and Meracydian Clone 41.
Given that 21 DC/LQ and 41 DC/MC have the same HP, I've assumed all dread beasts have the same HP on any given set and filled in accordingly.

Regarding 1 MC's damage, I don't know why my original testing gave 26k, but more recent tests are consistently around 34k.