### PR TITLE
Remove "stacking" from vuln up descriptions, since vuln up always stacks

### DIFF
--- a/_eo_021_enemies/vouivre.md
+++ b/_eo_021_enemies/vouivre.md
@@ -22,7 +22,7 @@ abilities:
   - name: Bombination
     potency: 350
     type: Magic
-    description: 'huge pointblank AoE with late telegraph; inflicts stacking
+    description: 'huge pointblank AoE with late telegraph; inflicts
     vulnerability up (15% per stack, 30s); only used out of combat'
 job_specifics:
   SGE:

--- a/_eo_041_enemies/kukulkan.md
+++ b/_eo_041_enemies/kukulkan.md
@@ -20,7 +20,7 @@ abilities:
   - name: Bombination
     potency: 200
     type: Magic
-    description: "huge pointblank AoE with late telegraph; inflicts stacking
+    description: "huge pointblank AoE with late telegraph; inflicts
     vulnerability up (10% per stack, 30s); only used out of combat; can be
     LoSed"
 notes:

--- a/_eo_051_enemies/leech.md
+++ b/_eo_051_enemies/leech.md
@@ -18,8 +18,8 @@ abilities:
   - name: Acid Mist
     potency: 140
     type: Magic
-    description: "instant pointblank AoE; inflicts stacking vulnerability up
-    (10% per stack, 20s); 12 second cooldown"
+    description: "instant pointblank AoE; inflicts vulnerability up (10% per
+    stack, 20s); 12 second cooldown"
 notes:
   - "Acid Mist is fairly easy to avoid by kiting"
 job_specifics:

--- a/_eo_081_enemies/deepeye.md
+++ b/_eo_081_enemies/deepeye.md
@@ -19,6 +19,6 @@ abilities:
   - name: Heirloom Scream
     potency: 110
     type: Magic
-    description: "instant untelegraphed pointblank AoE; inflicts stacking
-    vulnerability up (5% per stack, 25s)"
+    description: "instant untelegraphed pointblank AoE; inflicts vulnerability
+    up (5% per stack, 25s)"
 ---

--- a/_eo_floorsets/001.md
+++ b/_eo_floorsets/001.md
@@ -25,8 +25,8 @@ boss_abilities:
   - name: Mandrashock (pachypodium mine adds)
     potency: 250
     type: Magic
-    description: 'telegraphed pointblank AoE; inflicts stacking vulnerability
-    up (25% per stack, 1m)'
+    description: 'telegraphed pointblank AoE; inflicts vulnerability up (25%
+    per stack, 1m)'
 boss_notes:
   - 'The arena is a 3x3 grid of mines (pachypodium mine adds)'
   - note: 'Rotation:'

--- a/_eo_floorsets/011.md
+++ b/_eo_floorsets/011.md
@@ -25,13 +25,13 @@ boss_abilities:
   - name: 'Piercing Laser'
     potency: 250
     type: Magic
-    description: 'telegraphed line AoE; inflicts stacking vulnerability up (20%
-    per stack, 1m)'
+    description: 'telegraphed line AoE; inflicts vulnerability up (20% per
+    stack, 1m)'
   - name: 'Flame Breath (cloned shield dragon adds)'
     potency: 250
     type: Magic
-    description: 'conal AoE with late telegraph; inflicts stacking
-    vulnerability up (20% per stack, 1m)'
+    description: 'conal AoE with late telegraph; inflicts vulnerability up (20%
+    per stack, 1m)'
 boss_notes:
   - note: 'Initial actions:'
     subnotes:

--- a/_eo_floorsets/021.md
+++ b/_eo_floorsets/021.md
@@ -46,8 +46,8 @@ boss_abilities:
     type: Magic
     description: "triggered whenever you touch an add"
 boss_notes:
-  - "All damage other than the boss's auto-attack inflicts stacking
-    vulnerability up (20% per stack, 1m)"
+  - "All damage other than the boss's auto-attack inflicts vulnerability up
+    (20% per stack, 1m)"
   - note: "Initial actions:"
     subnotes:
       - Creature of Darkness

--- a/_eo_floorsets/041.md
+++ b/_eo_floorsets/041.md
@@ -79,9 +79,8 @@ boss_notes:
   attention to the order of elements in the ability name - ice/cold is
   pointblank and thunder is donut"
   - "All ice/thunder AoEs deal 900 potency magic damage (~50k to a DPS/healer)
-  and inflict stacking vulnerability up (20% per stack, 1m) along with
-  deep freeze (magic DoT potency 150, 6s) or paralysis (15s), uncurable with
-  Esuna"
+  and inflict vulnerability up (20% per stack, 1m) along with deep freeze
+  (magic DoT potency 150, 6s) or paralysis (15s), uncurable with Esuna"
   - "Ram's + Dragon's Voice combo is survivable with steel"
   - "Charge tether is potency 2700 when too close, which will one-shot
   DPS/healers through steel"

--- a/_eo_floorsets/051.md
+++ b/_eo_floorsets/051.md
@@ -27,12 +27,12 @@ boss_abilities:
     potency: 900
     type: Physical
     description: "90 degree conal AoE with late telegraph - get behind;
-    inflicts stacking vulnerability up (20% per stack, 1m)"
+    inflicts vulnerability up (20% per stack, 1m)"
   - name: Bullish Swing
     potency: 2700
     type: Physical
     description: "pointblank AoE with late telegraph - get away; inflicts
-    stacking vulnerability up (20% per stack, 1m)"
+    vulnerability up (20% per stack, 1m)"
   - name: Thundercall
     potency: 200
     type: Magic

--- a/_eo_floorsets/061.md
+++ b/_eo_floorsets/061.md
@@ -27,8 +27,8 @@ boss_abilities:
     potency: 600
     type: Magic
     description: "donut AoE if boss has a big blue glowing animation;
-    pointblank AoE otherwise; late telegraph. Inflicts stacking vulnerability
-    up (10% per stack, 30s)"
+    pointblank AoE otherwise; late telegraph. Inflicts vulnerability up (10%
+    per stack, 30s)"
   - name: Roar
     potency: 160
     type: Magic
@@ -39,7 +39,7 @@ boss_abilities:
     potency: 600
     description: "pointblank AoE (magic damage) if boss has a big blue glowing
     animation; wide conal AoE (physical damage) otherwise; late telegraph.
-    Inflicts stacking vulnerability up (10% per stack, 30s)"
+    Inflicts vulnerability up (10% per stack, 30s)"
 boss_notes:
   - note: "Rotation:"
     subnotes:

--- a/_hoh_051_enemies/kamanari.md
+++ b/_hoh_051_enemies/kamanari.md
@@ -15,7 +15,7 @@ vulnerabilities:
   slow: true
   stun: true
 notes:
-  - 'auto-attacks inflict stacking vulnerability up (5% per stack, 6s)'
+  - 'auto-attacks inflict vulnerability up (5% per stack, 6s)'
 job_specifics:
   MCH:
     difficulty: Easy

--- a/_hoh_061_enemies/mannenso.md
+++ b/_hoh_061_enemies/mannenso.md
@@ -21,8 +21,7 @@ abilities:
     description: 'instant'
   - name: 'Anemochory'
     potency: n/a
-    description: 'instant; inflicts stacking vulnerability up (5%? per stack,
-    10s)'
+    description: 'instant; inflicts vulnerability up (5%? per stack, 10s)'
 job_specifics:
   DRK:
     difficulty: Easy

--- a/_hoh_081_enemies/koki.md
+++ b/_hoh_081_enemies/koki.md
@@ -26,9 +26,9 @@ abilities:
   - name: Blood Moon
     potency: 50
     type: Magic
-    description: 'untelegraphed huge pointblank AoE; inflicts stacking
-    vulnerability up (5%? per stack, 30s). Can be LoSed, and fully shielding
-    the damage also blocks the vulnerability up'
+    description: 'untelegraphed huge pointblank AoE; inflicts vulnerability up
+    (5%? per stack, 30s). Can be LoSed, and fully shielding the damage also
+    blocks the vulnerability up'
 notes:
   - 'If you let it do one auto-attack after Vile Utterance and then duck behind
   a corner, you should avoid the vulnerability up'

--- a/_hoh_081_enemies/rowan.md
+++ b/_hoh_081_enemies/rowan.md
@@ -28,7 +28,7 @@ abilities:
   - name: Chest Thump
     potency: 30
     type: Magic
-    description: 'huge 1.5 room instant AoE that inflicts stacking physical
+    description: 'huge 1.5 room instant AoE that inflicts physical
     vulnerability up (5% per stack, max 8 stacks, 8s). Only used out of combat
     during Ripe Banana'
 notes:

--- a/_hoh_floorsets/001.md
+++ b/_hoh_floorsets/001.md
@@ -25,8 +25,8 @@ boss_abilities:
   - name: Amorphous Applause
     type: Physical
     potency: 250
-    description: 'telegraphed half room AoE; inflicts stacking vulnerability up
-    (40% per stack, max 16 stacks, 45s)'
+    description: 'telegraphed half room AoE; inflicts vulnerability up (40% per
+    stack, max 16 stacks, 45s)'
 boss_notes:
   - note: 'Rotation:'
     subnotes:

--- a/_hoh_floorsets/021.md
+++ b/_hoh_floorsets/021.md
@@ -35,9 +35,9 @@ boss_abilities:
   - name: 'Lightning Bolt (cloud AoE)'
     potency: 130
     type: Magic
-    description: 'telegraphed circle AoE; inflicts stacking vulnerability up
-    (20% per stack, 1m). Vulnerability up is applied even if the damage is
-    fully shielded'
+    description: 'telegraphed circle AoE; inflicts vulnerability up (20% per
+    stack, 1m). Vulnerability up is applied even if the damage is fully
+    shielded'
 boss_notes:
   - note: 'Opening sequence:'
     subnotes:

--- a/_hoh_floorsets/041.md
+++ b/_hoh_floorsets/041.md
@@ -17,13 +17,13 @@ boss_abilities:
   - name: Rusting Claw
     potency: 750
     type: Physical
-    description: 'untelegraphed conal AoE; inflicts stacking vulnerability up
-    (20% per stack, 1m)'
+    description: 'untelegraphed conal AoE; inflicts vulnerability up (20% per
+    stack, 1m)'
   - name: Words of Woe
     potency: 700
     type: Magic
-    description: 'untelegraphed line AoE; inflicts stacking vulnerability up
-    (20% per stack, 1m)'
+    description: 'untelegraphed line AoE; inflicts vulnerability up (20% per
+    stack, 1m)'
   - name: Eye of the Fire
     potency: 'n/a'
     description: '360 degree gaze inflicting confused (20s) - look away'

--- a/_potd_111_enemies/slime.md
+++ b/_potd_111_enemies/slime.md
@@ -22,9 +22,9 @@ abilities:
     type: Unique
     description: 'instant AoE sacrificial enrage; used 37 seconds after pull'
 notes:
-  - 'Acid Spray inflicts stacking physical vulnerability up (+10% per stack,
-    max 8 stacks, 5s); this ability does magic damage, so its own damage is
-    not affected'
+  - 'Acid Spray inflicts physical vulnerability up (+10% per stack, max 8
+    stacks, 5s); this ability does magic damage, so its own damage is not
+    affected'
   - 'Can be slowed if transfigured via Pomander of Witching'
 job_specifics:
   SGE:

--- a/_potd_171_enemies/sasquatch.md
+++ b/_potd_171_enemies/sasquatch.md
@@ -28,7 +28,7 @@ abilities:
   - name: Chest Thump
     potency: 30
     type: Magic
-    description: 'huge 1.5 room instant AoE that inflicts stacking physical
+    description: 'huge 1.5 room instant AoE that inflicts physical
     vulnerability up (5% per stack, max 8 stacks, 8s). Only used out of combat
     during Ripe Banana'
 notes:


### PR DESCRIPTION
Didn't bother with a changelog entry because there's no real content change here, just cleanup.