### PR TITLE
Correction: PotD 11+ can have 3 enchantments

### DIFF
--- a/_data/changelog.yml
+++ b/_data/changelog.yml
@@ -1,3 +1,6 @@
+- date: 2023-08-26
+  updates:
+    - "Correction: PotD 11+ can have up to 3 (not 2) enchantments"
 - date: 2023-08-09
   updates:
     - "Orthosystem α is vulnerable to slow (requires witching to apply via

--- a/_potd_floorsets/011.md
+++ b/_potd_floorsets/011.md
@@ -89,8 +89,8 @@ boss_job_specifics:
 Beware of slime enrage and stay away from snakes if you hit a toading trap!
 There is 1 known [wall trap](/wall_traps.html#potd-11-19).
 
-The Knockback Penalty enchantment does not appear in this set. Floors can have
-up to 2 enchantments.
+The Knockback Penalty enchantment does not appear in this set. Starting from
+this set, floors can have up to 3 enchantments.
 
 If solo, you probably want to full clear this set for exp.
 

--- a/_potd_floorsets/021.md
+++ b/_potd_floorsets/021.md
@@ -88,8 +88,7 @@ boss_job_specifics:
 Watch out for minotaur patrols' untelegraphed AoE. There is also a known
 [wall trap](/wall_traps.html#potd-21-29).
 
-Starting from this set, all enchantments can appear and floors can have up to
-3 enchantments.
+Starting from this set, all floor enchantments can appear.
 
 Pomanders of resolution and raising do not drop at all on this set. Affluence,
 flight, and alteration do not drop on floor 29.


### PR DESCRIPTION
First time in well over 500 12-19 floors, but it finally happened...
![15triple](https://github.com/djcooke/compendium/assets/111935183/c8221e58-46b0-411f-9155-07463c1a681c)
