### PR TITLE
Update kunoichi and update notes on floors 71-100

### DIFF
--- a/_eo_071_enemies/kunoichi.md
+++ b/_eo_071_enemies/kunoichi.md
@@ -23,4 +23,9 @@ abilities:
     potency: 50 (x3)
     type: Physical
     description: "instant 3-hit attack"
+  - name: Assassinate
+    potency: 150% of max HP
+    type: Unique
+    description: "used on players with less than 20% of max HP"
+    warning: other    
 ---

--- a/_eo_floorsets/071.md
+++ b/_eo_floorsets/071.md
@@ -110,3 +110,6 @@ boss_job_specifics:
       - "6m40s with Doga (6.35)"
       - "6m10s with strength and Doga (6.35)"
 ---
+
+
+71-73 has high landmine chance.

--- a/_eo_floorsets/081.md
+++ b/_eo_floorsets/081.md
@@ -117,3 +117,5 @@ boss_job_specifics:
       - "6m30s with Doga and the dread beast damage up buff (6.35)"
       - "4m15s with strength and Onion Knight (6.35)"
 ---
+
+Silver chests from here on have significant chance to be demiclones.

--- a/_eo_floorsets/081.md
+++ b/_eo_floorsets/081.md
@@ -118,4 +118,4 @@ boss_job_specifics:
       - "4m15s with strength and Onion Knight (6.35)"
 ---
 
-Silver chests from here on have significant chance to be demiclones.
+Silver chests have significant chance to be demiclones.

--- a/_eo_floorsets/091.md
+++ b/_eo_floorsets/091.md
@@ -131,6 +131,6 @@ boss_job_specifics:
       - "7m15s with strength and Onion Knight (6.35)"
 ---
 
-The final boss is on floor 99. Floor 100 is just a long run to the finish. Make
+Silver chests have significant chance to be demiclones. The final boss is on floor 99. Floor 100 is just a long run to the finish. Make
 sure you have time for this as it takes about 1m5s with 2 sprints - one at the
 start and another just before the finish.


### PR DESCRIPTION
Kunoichi has an assassinate like Ninja, adding that to their profile.

Adding note on floorset 71 that there's an increased landmine chance on floor 71-73.

Adding notes on floorsets 81 and 91 that demiclones have an increased drop rate from silvers.