### PR TITLE
Update to fitter.md and taur.md

### DIFF
--- a/_eo_091_enemies/fitter.md
+++ b/_eo_091_enemies/fitter.md
@@ -22,6 +22,9 @@ abilities:
     type: Magic
     description: "untelegraphed huge pointblank AoE; only used out of combat"
     warning: idle
+  - name: Allagan Meteor
+    description: "Large telegraphed pointblank AOE"
+    warning: pointblank
 notes:
   - "As of patch 6.35, a bug in the game sometimes causes the Unholy cast bar
     and effect to be hidden when the Lethargy protomander is active. Be VERY

--- a/_eo_091_enemies/taur.md
+++ b/_eo_091_enemies/taur.md
@@ -14,7 +14,7 @@ vulnerabilities:
   heavy: false
   sleep: false
   slow: true
-  stun: unknown
+  stun: false
 abilities:
   - name: 32-tonze Swipe
     description: "large conal AoE with late telegraph - get to side or behind"


### PR DESCRIPTION
Addition of new skill to fitter:
Allagan Meteor
Likely triggered by % hp, was 30% upon finishing Allagan Fear and immediately began casting. 

Update stun status of orthotaur to false.
![Taur - Stun status](https://github.com/djcooke/compendium/assets/64555268/88389296-9c2c-494e-9046-f990acec991b)
![Fitter- Allagan meteor](https://github.com/djcooke/compendium/assets/64555268/5a36bb22-a764-4260-81af-89036b03fdf1)

