### PR TITLE
Update zenki starting floor and add floor 90 boss time/notes for sage

### DIFF
--- a/_hoh_091_enemies/zenki.md
+++ b/_hoh_091_enemies/zenki.md
@@ -3,7 +3,7 @@ name: Heavenly Zenki
 nickname: Zenki
 family: Arch Demon
 image: zenki.png
-start_floor: 97
+start_floor: 96
 end_floor: 99
 agro: Sight
 hp: 70086
@@ -31,4 +31,8 @@ job_specifics:
       - 'Steel recommended'
   PLD:
     difficulty: 'Easy'
+  SGE:
+    difficulty: 'Hard'
+    notes:
+      - 'Steel recommended'
 ---

--- a/_hoh_floorsets/081.md
+++ b/_hoh_floorsets/081.md
@@ -121,6 +121,10 @@ boss_job_specifics:
   SGE:
     timing:
       - '12m45s with no offensive pomanders (6.0)'
+      - '10m with 1 strength (7.15)'
+    notes:
+      - 'Use melee uptime strategy'
+      - 'Steel is not required'
   WAR:
     timing:
       - '8m15s with strength and 2 frailty (6.28)'


### PR DESCRIPTION
changed zenki starting floor from 97 to 96 and added difficulty description for sage . added notes/time for floor 90 boss for sage
![image](https://github.com/user-attachments/assets/8b4c8ed9-e03f-468b-942f-4ee5f9743752)
![image](https://github.com/user-attachments/assets/2d9b305e-e4dd-4759-b98f-b38ba7c36917)
![image](https://github.com/user-attachments/assets/434e3aa2-64be-40a0-848f-8b576c1aed21)

