### PR TITLE
fix: EO bosses' name for floors 30/40

### DIFF
--- a/_eo_floorsets/021.md
+++ b/_eo_floorsets/021.md
@@ -9,7 +9,7 @@ enemies_per_room: '3-4'
 kills_per_passage: '3-7'
 respawns: '1m'
 hoard_type: 'Bronze-tinged Sack'
-boss: "Tiamat Clone"
+boss: "Tiamat's clone"
 boss_image: tiamat_clone.png
 boss_hp: 2473000 (approx.)
 boss_attack_damage: 5006

--- a/_eo_floorsets/031.md
+++ b/_eo_floorsets/031.md
@@ -9,7 +9,7 @@ enemies_per_room: '2-3'
 kills_per_passage: '4-8 (rarely 3 or 9)'
 respawns: '?'
 hoard_type: 'Silver-tinged Sack'
-boss: "Twintania Clone"
+boss: "Twintania's clone"
 boss_image: twintania_clone.png
 boss_hp: 1710000 (approx.)
 boss_attack_damage: 5331


### PR DESCRIPTION
Tiamat's clone and Twintania's clone names no longer are correct as of [#84](https://github.com/djcooke/compendium/issues/84), this PR fixes it again (so data is correct and to avoid having ODD's parser hating on me)