### PR TITLE
Improving developer QoL through rake and linting

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -1,0 +1,4 @@
+pre-push:
+  commands:
+    lint:
+      run: ./scripts/checks.sh

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,17 @@
+{
+  "default": true,
+  "MD001": false,
+  "MD007": false,
+  "MD009": false,
+  "MD012": false,
+  "MD013": false,
+  "MD025": false,
+  "MD026": false,
+  "MD032": false,
+  "MD033": false,
+  "MD034": false,
+  "MD036": false,
+  "MD041": false,
+  "MD045": false,
+  "MD047": false
+}

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,30 @@
+# yamllint configuration
+# See: https://yamllint.readthedocs.io/en/stable/configuration.html
+
+extends: default
+
+rules:
+  # Allow longer lines for readability
+  line-length:
+    max: 120
+    level: warning
+  
+  # Be more flexible with indentation
+  indentation:
+    spaces: 2
+    indent-sequences: true
+    check-multi-line-strings: false
+  
+  # Allow some common YAML patterns
+  comments:
+    min-spaces-from-content: 1
+    require-starting-space: true
+  
+  # Don't be too strict about document separators
+  document-start: disable
+  document-end: disable
+  
+  # Allow empty values (common in Jekyll front matter)
+  empty-values:
+    forbid-in-block-mappings: false
+    forbid-in-flow-mappings: false

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,13 @@ gem "jekyll", "~> 4.3"
 #  gem "jekyll-feed", "~> 0.12"
 #end
 
+group :development do
+  gem 'lefthook' # Used for running git hooks
+  gem 'rake' # Used for setup and maintenance tasks
+  gem 'logger' # Silence Ruby 3.5+ warnings
+  gem 'benchmark' # Silence Ruby 3.5+ warnings
+end
+
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.
 platforms :mingw, :x64_mingw, :mswin, :jruby do
@@ -26,4 +33,3 @@ end
 
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
+    benchmark (0.4.1)
     bigdecimal (3.1.9)
     colorator (1.1.0)
     concurrent-ruby (1.3.5)
@@ -48,10 +49,12 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
+    lefthook (1.12.2)
     liquid (4.0.4)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     mercenary (0.3.6)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -74,7 +77,11 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  benchmark
   jekyll (~> 4.3)
+  lefthook
+  logger
+  rake
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)

--- a/LINTING.md
+++ b/LINTING.md
@@ -1,0 +1,28 @@
+# Linting
+
+This project uses YAML and Markdown linting to ensure non-savvy contributors don't have to worry about formatting issues.
+
+To run:
+
+```sh
+rake lint
+```
+
+## Notes on (`.markdownlint.json`)
+
+The following rules are disabled for Jekyll compatibility:
+
+- `MD001`: Heading levels increment by one
+- `MD007`: Unordered list indentation
+- `MD009`: No trailing spaces
+- `MD012`: No multiple consecutive blank lines
+- `MD013`: Line length
+- `MD025`: Single title/h1
+- `MD026`: No trailing punctuation in headings
+- `MD032`: Lists surrounded by blank lines
+- `MD033`: No inline HTML
+- `MD034`: No bare URLs
+- `MD036`: No emphasis for headers
+- `MD041`: First line in file should be h1
+- `MD045`: Images should have alt text
+- `MD047`: Single trailing newline

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Deep Dungeon Compendium
 
-Contributors: please read the [contributing guidelines](./contributing.md).
+Contributors: please read the [contributing guidelines](./pages/contributing.md).
 
 ## Local Development
 
@@ -9,15 +9,21 @@ Contributors: please read the [contributing guidelines](./contributing.md).
 - Ruby (see `.ruby-version` for the required version)
 - Bundler (`gem install bundler` if needed)
 
-To run:
+Setup:
 
 ```sh
 bundle install
-bundle exec jekyll serve
+rake setup
+```
+
+To run:
+
+```sh
+rake serve
 ```
 
 Site will be available at http://localhost:4000
 
 #### Deployment
 
-Github pages deploys are handled via workflow (see `.github/workflows/deploy-github-pages.yml`).
+Github pages deploys are handled via workflow [`deploy-github-pages.yml`](.github/workflows/deploy-github-pages.yml).

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ task :setup do
   system("bundle install") || abort("Bundle install failed")
   
   # Install git hooks if lefthook config exists
-  if File.exist?("lefthook.yml")
+  if File.exist?(".lefthook.yml")
     system("bundle exec lefthook install") || abort("Failed to install git hooks")
     puts "Git hooks installed"
   end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+# ^ This comment makes all string literals immutable by default in this file.
+
+# Development environment setup
+desc "Set up the development environment"
+task :setup do
+  puts "Setting up development environment..."
+  
+  system("bundle install") || abort("Bundle install failed")
+  
+  # Install git hooks if lefthook config exists
+  if File.exist?("lefthook.yml")
+    system("bundle exec lefthook install") || abort("Failed to install git hooks")
+    puts "Git hooks installed"
+  end
+  
+  puts "Setup complete! Run 'rake serve' to start development server"
+end
+
+# Linting
+desc "Run linting checks"
+task :lint do
+  system("./scripts/checks.sh") || abort("Linting failed")
+end
+
+desc "Run full check (lint + build)"
+task :check do
+  Rake::Task[:lint].invoke
+  Rake::Task[:build].invoke
+end
+
+# Build
+desc "Build the Jekyll site"
+task :build do
+  system("bundle exec jekyll build") || abort("Build failed")
+end
+
+# Development server
+desc "Serve the Jekyll site locally"
+task :serve do
+  system("bundle exec jekyll serve")
+end
+
+# Default task when just running 'rake'
+task default: :serve

--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@
 # For technical reasons, this file is *NOT* reloaded automatically when you use
 # 'bundle exec jekyll serve'. If you change this file, please restart the server process.
 #
-# If you need help with YAML syntax, here are some quick references for you: 
+# If you need help with YAML syntax, here are some quick references for you:
 # https://learn-the-web.algonquindesign.ca/topics/markdown-yaml-cheat-sheet/#yaml
 # https://learnxinyminutes.com/docs/yaml/
 

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Linting YAML..."
+yamllint -c .yamllint.yml _config.yml _data/
+
+echo "Linting Markdown..."
+markdownlint -c .markdownlint.json '**/*.md'
+
+echo "Building site..."
+bundle exec jekyll build --quiet
+
+echo "✅ All checks passed!"


### PR DESCRIPTION
This PR improves developer quality of life by simplifying setup and enforcing consistent linting for commonly edited files.

### Changes

- Added a `Rakefile` with tasks for setup, linting, building, and serving the Jekyll site.
- Added a `lefthook.yml` for a pre-push hook that runs checks via `scripts/checks.sh`.
- Added `.markdownlint.json` and `.yamllint.yml` to modify rules to support jekyll.
- Updated `README.md` with instructions for setup and development using the new Rake tasks.

<img width="298" height="177" alt="image" src="https://github.com/user-attachments/assets/56e49bf4-5241-45c1-8944-0b936c9cb1e4" />

> Note: the idea is to help improve dev QoL on setup and also making sure that reviewing PRs becomes easier as typos/issues in `.md` and `.yaml` files will occur less.
