### PR TITLE
Generating correct robots.txt

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   High deep dungeons in Final Fantasy XIV. Intended for use as a guide to both
   groups and solo players looking to clear on any job.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: ""     # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://www.ddcompendium.com" # this is necessary as well as the CNAME file, but keep them in sync
 github_username: djcooke
 ga_measurement_id: G-9Y46PNPE95
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,7 @@
+---
+layout: null
+---
+User-agent: *
+Disallow:
+
+Sitemap: {{ site.url }}/sitemap.xml


### PR DESCRIPTION
This PR has jekyll generate a correct robots.txt

https://www.ddcompendium.com/robots.txt, is wrong.

Changes dynamically create,

<img width="378" height="96" alt="image" src="https://github.com/user-attachments/assets/c6e71f9d-02e3-47df-b722-a92ffe3cd167" />

