### PR TITLE
PotD boss damage fixes and misc updates

### DIFF
--- a/_data/changelog.yml
+++ b/_data/changelog.yml
@@ -1,3 +1,12 @@
+- date: 2026-01-18
+  updates:
+    - "Updated Knowledge/Preparation pages to reflect patch 7.31 changes to
+      PotD and general differences in PT"
+    - "Updated approprate food/tincture for EO and PT"
+    - "Updated sources of Phoenix Downs"
+    - "Clarified damage from puddles in PotD boss encounters"
+    - "Corrected PotD 130 boss autoattack damage"
+    - "Above changes courtesy of vaxherd"
 - date: 2026-01-07
   updates:
     - "Added missing mimic images"

--- a/collections/_potd_floorsets/021.md
+++ b/collections/_potd_floorsets/021.md
@@ -12,7 +12,7 @@ hoard_type: Bronze-trimmed Sack
 boss: Ningishzida
 boss_image: ningishzida.png
 boss_hp: 46768
-boss_attack_damage: 324
+boss_attack_damage: 325
 boss_abilities:
   - name: Dissever
     potency: 150
@@ -22,7 +22,7 @@ boss_abilities:
     potency: 50
     type: Magic
     description: 'instant circle AoE on random player; leaves burn puddle
-    (unique DoT potency 350)'
+    (unique DoT for ~700 damage/tick, pierces Steel)'
   - name: Ball of Ice
     potency: 50
     type: Magic

--- a/collections/_potd_floorsets/031.md
+++ b/collections/_potd_floorsets/031.md
@@ -18,7 +18,7 @@ boss_abilities:
     potency: 400
     type: Magic
     description: 'telegraphed circle AoE; leaves a bleed puddle (unique DoT
-    potency 40)'
+    for ~200 damage/tick)'
   - name: Entropic Flame
     potency: 400
     type: Magic

--- a/collections/_potd_floorsets/051.md
+++ b/collections/_potd_floorsets/051.md
@@ -23,7 +23,7 @@ boss_abilities:
     potency: 60
     type: Magic
     description: 'instant large circle AoE leaving bleed puddle (unique DoT
-    potency 70)'
+    for ~500 damage/tick, pierces Steel)'
   - name: Valfodr
     potency: 60
     type: Physical

--- a/collections/_potd_floorsets/121.md
+++ b/collections/_potd_floorsets/121.md
@@ -13,7 +13,7 @@ resolution_possible: true
 boss: Alfard
 boss_image: alfard.png
 boss_hp: 239843
-boss_attack_damage: 324
+boss_attack_damage: 1103
 boss_abilities:
   - name: Dissever
     potency: 120
@@ -23,7 +23,7 @@ boss_abilities:
     potency: 75
     type: Magic
     description: 'instant circle AoE on random player; leaves burn puddle
-    (unique DoT potency 450)'
+    (unique DoT for ~3000 damage/tick, pierces Steel)'
   - name: Ball of Ice
     potency: 75
     type: Magic

--- a/collections/_potd_floorsets/131.md
+++ b/collections/_potd_floorsets/131.md
@@ -19,7 +19,7 @@ boss_abilities:
     potency: 400
     type: Magic
     description: 'telegraphed circle AoE; leaves a bleed puddle (unique DoT
-    potency 1300)'
+    for ~10k damage/tick, pierces Steel)'
   - name: Entropic Flame
     potency: 1100
     type: Magic

--- a/collections/_potd_floorsets/151.md
+++ b/collections/_potd_floorsets/151.md
@@ -23,7 +23,7 @@ boss_abilities:
     potency: 65
     type: Magic
     description: 'instant large circle AoE leaving bleed puddle (unique DoT
-    potency 100)'
+    for ~3000 damage/tick, pierces Steel)'
   - name: Valfodr
     potency: 60
     type: Physical

--- a/collections/_potd_floorsets/191.md
+++ b/collections/_potd_floorsets/191.md
@@ -37,6 +37,6 @@ got! Go in with a plan based on what pomanders you have.
     still
 * The early floor mobs are easiest, so best to save flights and rages for mid
   or late floors
-* Don't forget to use up your safties and sights
+* Don't forget to use up your safeties and sights
 
 Be aware of the [wall traps](/wall_traps.html#potd-151-199) on these floors.

--- a/pages/knowledge.md
+++ b/pages/knowledge.md
@@ -190,6 +190,10 @@ chests:
   importantly, potsherds. Potsherds ("Orthos Aetherpool Fragments" in EO) can
   be exchanged for several items, including Sustaining/Empyrean/Orthos Potions,
   which grant a potent regen effect and are essential for soloing
+  * Specific to PotD, Sustaining Potions are frequently dropped by normal
+    enemies when defeated, so you typically won't need to farm potsherds to
+    trade for them. Enemies in other DDs drop ordinary potions appropriate
+    to the dungeon level (Max-Potion, Super-Potion, etc.)
 * **Silver**: Can have one of several effects
   * Upgrade your Aetherpool arm or armor
   * Chest explodes, dealing 70% max HP damage to any players and enemies nearby

--- a/pages/preparation.md
+++ b/pages/preparation.md
@@ -66,7 +66,7 @@ boss - anything you get from bronze chests stays in your inventory.
 **HoH/EO**: Beating floor 30 always gives you a potsherd, so it's easiest to
 just spam floor 21-30 in a party or matched groups.
 
-**PT**: You can spam floor 21-40 like HoH/EO, but floor 31-40 or 51-60 are
+**PT**: You can spam floor 21-30 like HoH/EO, but floor 31-40 or 51-60 are
 usually a better choice because bronze chests drop multiple items and you'll
 have a decent chance of picking up extra potsherds even in a party.
 

--- a/pages/preparation.md
+++ b/pages/preparation.md
@@ -21,16 +21,21 @@ better chance.
 
 ### Levelling Aetherpool
 
-**PotD**: There's no easily-spammable floorset that gives guaranteed upgrades, so
-you'll want to go for silver chests. You can spam 51-60 in matched groups until
-the rate of upgrades gets bad. After that, it's fastest to go to the highest
-levels you can as a group. Another option is to go up to floor 100 with matched
-groups. Soloing as far as you can also works, and while it will be more
-difficult with low aetherpool levels, it will still be good experience.
+**PotD**: As of patch 7.31, silver chest and boss aetherpool rewards have been
+drastically increased, such that you'll almost always be capped for your
+current level or floor. If you spend aetherpool on grips for the weapons, a
+run or two of 51-60 should be enough to bring you back to 99/99.
 
-**HoH/EO/PT**: Beating floor 30 always gives +1 to both arm and armor, so it's
+**HoH/EO**: Beating floor 30 always gives +1 to both arm and armor, so it's
 easiest to just spam floor 21-30 in a party or matched groups. Bonus: you'll
 also be farming potsherds this way.
+
+**PT**: As with HoH/EO, beating floor 30 (and every subsequent floorset)
+rewards an aetherpool increase, but later floors give greater bonuses (+2/+2
+at 40, +4/+4 at 60), so 31+ or 51+ are a better choice if your current arm and
+armor are high enough. That said, aetherpool rewards are tuned so you can
+expect to naturally get close to 99/99 from a 1-100 run, so like PotD, this
+is mostly an issue only if you spend aetherpool on weapon grips.
 
 When playing with matched groups, it's nice to mention that you're going for
 silver chests, and also make sure not to slow down the group too much.
@@ -41,21 +46,29 @@ silver chests, and also make sure not to slow down the group too much.
 ## Regen Potions
 
 <div class="surfacePane" markdown="1">
-Sustaining Potions (PotD), Empyrean Potions (HoH), Orthos Potions (EO), and Pilgrim's Potions (PT)
-grant a potent regen effect. These are extremely helpful to soloing especially,
-and you will want to have a lot of them going into a difficult floorset. Get
-them by trading potsherds to an NPC outside the dungeon.
+Sustaining Potions (PotD), Empyrean Potions (HoH), Orthos Potions (EO), and
+Pilgrim's Potions (PT) grant a potent regen effect. These are extremely
+helpful to soloing especially, and you will want to have a lot of them going
+into a difficult floorset. Get them by trading potsherds to an NPC outside the
+dungeon.
 
 ### Farming Potsherds
 
-**PotD**: In a party, bronze chest drops go to random players, so it's best to
-farm potsherds solo. Since deeper floors have a better chance of potsherd
-drops, you'll want to start on floor 51 and solo as far as you can without
-using many sustaining potions. Preferably use a job that doesn't require many
-sustaining potions, such as a tank, physical ranged, or red mage.
+**PotD**: You typically won't need to farm potsherds for PotD because
+Sustaining Potions frequently drop from defeating normal enemies, and
+potsherds also drop fairly regularly from bronze chests. If you do need to
+farm, keep in mind that when in a party, bronze chest drops go to random
+players, so it's best to farm potsherds solo. You can either spam 51-60 from
+the entrance NPC, or set up a 51+ file with full Affluence/Alteration/Fortune
+pomanders, then repeatedly run to 60 and leave the duty without killing the
+boss - anything you get from bronze chests stays in your inventory.
 
-**HoH/EO/PT**: Beating floor 30 always gives you a potsherd, so it's easiest to
+**HoH/EO**: Beating floor 30 always gives you a potsherd, so it's easiest to
 just spam floor 21-30 in a party or matched groups.
+
+**PT**: You can spam floor 21-40 like HoH/EO, but floor 31-40 or 51-60 are
+usually a better choice because bronze chests drop multiple items and you'll
+have a decent chance of picking up extra potsherds even in a party.
 
 [Back to top](#top)
 </div>
@@ -67,11 +80,11 @@ just spam floor 21-30 in a party or matched groups.
 
 Potions are great to have in deep dungeons as an extra heal. The best potion to
 use depends on your max HP, so will mainly be based on your level, job, and
-food. In the early floors of PotD, the type of potion that's dropping from the
-floor you're on is likely sufficient. By the time you hit 60, you'll want to
-use either Max or Super Potions, depending on your job. Note that Super Potions
-do not drop in PotD even though they are best for some jobs in the later
-floors. You will get tons of Super Potions from HoH.
+food. In the early floors of PotD, the type of potion that drops from bronze
+chests on your current floor is likely sufficient. By the time you hit level
+60, you'll want to use either Max or Super Potions, depending on your job.
+Note that Super Potions do not drop in PotD even though they are best for
+some jobs in the later floors. You will get tons of Super Potions from HoH.
 
 | Type (HQ) | Heals | Max | Best until Max HP |
 | :--- | :---: | --: | ----------------: |
@@ -92,22 +105,24 @@ is best for the job you're playing.
 
 For maximum HP in PotD, physical jobs (tank/melee/range) will need HQ i580 or
 higher food, while magic jobs (caster/healer) can make do with HQ i525 due to
-their lower VIT stat. In HoH, all jobs will need HQ i640+. For EO, take the
-highest level food available (i640 as of patch 6.4).
+their lower VIT stat. In HoH, all jobs will need HQ i640+. For EO and PT, take
+the highest level food available (i770 as of patch 7.4).
 
 ### Stat Potions
 
 Tinctures can be useful for a temporary damage boost, which is especially
 useful to tanks. Just note that they share a cooldown with HP potions. Any
 grade Infusion or Tincture will give the maximum effect in PotD; use grade
-3+ Tinctures in HoH, and grade 8+ Tinctures in EO and PT.
+3+ Tinctures in HoH, Gemdraughts (any grade) in EO, and the highest grade
+Gemdraught in PT (grade 4 as of patch 7.4).
 
 ### Misc
 
 * Echo Drops: Can cure silence from impeding traps
     * Shares a cooldown timer with regen potions
 * Phoenix Down: Good to have if you're in a party. These drop from bronze
-  chests in the earlier floors of both PotD and HoH.
+  chests in all Deep Dungeons, and can also be bought from item vendors (or
+  the marketboard).
 
 [Back to top](#top)
 </div>

--- a/pages/preparation.md
+++ b/pages/preparation.md
@@ -91,10 +91,11 @@ some jobs in the later floors. You will get tons of Super Potions from HoH.
 | Potion | 40% | 200 | 500 |
 | Hi-Potion | 40% | 440 | 1,257 |
 | Mega-Potion | 35% | 840 | 2,800 |
-| X-Potion | 30% | 1300 | 4,333 |
-| Max-Potion | 30% | 2400 | 9,600 |
-| Super-Potion | 25% | 3600 | 14,400 |
-| Hyper-potion | 25% | 11,000 | n/a |
+| X-Potion | 30% | 1,300 | 4,333 |
+| Max-Potion | 30% | 2,400 | 9,600 |
+| Super-Potion | 25% | 3,600 | 14,400 |
+| Hyper-Potion | 25% | 11,000 | 44,000 |
+| Ultra-Potion | 25% | 39,500 | n/a |
 
 ### Food
 


### PR DESCRIPTION
Started out as just the PotD damage, but I saw one thing and then another and then another and...

On the boss puddle damage specifically, I noticed that aside from piercing Steel, they seem to be centered on round numbers (e.g. floor 40 had a damage range of 190-210, which is 200 +/- 5%), so I suspect those are set independently of boss strength, and I noted those specific damage values in the description. I'm fairly certain they're accurate for floor 30/40/60 (data gave 665-731, 190-210, and 475-524 respectively); 130/140/160 are approximate values because they're a little sketchy to exhaustively test solo (especially 140).

Now that I think about it, maybe 130/140/160 were meant to be a little less punishing but got overlooked in the 6.0 stat squish? Only a curiosity at this point, but I (as a post-6.0 Necromancer) always thought 140 in particular seemed a bit extreme.
[Edit - looks like they were adjusted after all; I found an early Angelus 160 attempt that took ~5k ticks from the bleed puddles which now do ~3k. So much for that theory!]