### PR TITLE
Fix turtle name in PT41 header

### DIFF
--- a/collections/_pt_floorsets/041.md
+++ b/collections/_pt_floorsets/041.md
@@ -87,7 +87,7 @@ boss_job_specifics:
       - "2m30s with strength, haste, and barkbalm incense (7.35)"
 ---
 
-Welcome to the desert! Watch out for the turtles (Traverse Troubadour) which
+Welcome to the desert! Watch out for the turtles (Traverse Tolba) which
 eat your Steel buff.
 
 Pomanders of affluence, flight, and alteration do not drop on floor 49.


### PR DESCRIPTION
#127 updated the file for the turtle itself, but the floorset description still used the old name.