### PR TITLE
Add build time indexed search

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -46,6 +46,11 @@
   <!-- Scripts -->
   <script src="{{ '/assets/js/utils.js' | relative_url }}?{{ timestamp }}"></script>
   <script src="{{ '/assets/js/site.js' | relative_url }}?{{ timestamp }}"></script>
+  {% if page.external_scripts %}
+    {% for script in page.external_scripts %}
+    <script src="{{ script }}" defer></script>
+    {% endfor %}
+  {% endif %}
   {% if page.scripts %} 
     {% for script in page.scripts %}
     <script src="{{ '/assets/js/' | append: script | relative_url }}?{{ timestamp }}"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,6 +14,13 @@
     {% assign current_dungeon = page.dungeon %}
 
     <div id="nav">
+      <!-- Search -->
+      <a href="{{ '/search.html' | relative_url }}" id="navSearch"{% if current_url == '/search.html' %} class="current"{% endif %} title="Search" aria-label="Search">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z" />
+        </svg>
+      </a>
+
       <a href="{{ '/' | relative_url }}" {% if current_url=='/index.html' %} class="current" {% endif %}>
         Home
       </a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -45,7 +45,7 @@
           Floors
         </a>
         <div id="potdMenu" class="submenu{% if current_dungeon == 'potd' %} open{% endif %}">
-          <a class="navHeading" onclick="toggleOpen('potdMenu')">PotD</a>
+          <a class="navHeading" title="Palace of the Dead" onclick="toggleOpen('potdMenu')">PotD</a>
           <ul>
             {% for floorset in site.potd_floorsets %}
             <li>
@@ -58,7 +58,7 @@
         </div>
 
         <div id="hohMenu" class="submenu{% if current_dungeon == 'hoh' %} open{% endif %}">
-          <a class="navHeading" onclick="toggleOpen('hohMenu')">HoH</a>
+          <a class="navHeading" title="Heaven-on-High" onclick="toggleOpen('hohMenu')">HoH</a>
           <ul>
             {% for floorset in site.hoh_floorsets %}
             <li>
@@ -71,7 +71,7 @@
         </div>
 
         <div id="eoMenu" class="submenu{% if current_dungeon == 'eo' %} open{% endif %}">
-          <a class="navHeading" onclick="toggleOpen('eoMenu')">EO</a>
+          <a class="navHeading" title="Eureka Orthos" onclick="toggleOpen('eoMenu')">EO</a>
           <ul>
             {% for floorset in site.eo_floorsets %}
             <li>
@@ -84,7 +84,7 @@
         </div>
 
         <div id="ptMenu" class="submenu{% if current_dungeon == 'pt' %} open{% endif %}">
-          <a class="navHeading" onclick="toggleOpen('ptMenu')">PT</a>
+          <a class="navHeading" title="Pilgrim's Traverse" onclick="toggleOpen('ptMenu')">PT</a>
           <ul>
             {% for floorset in site.pt_floorsets %}
             <li>

--- a/_layouts/floorset.html
+++ b/_layouts/floorset.html
@@ -106,7 +106,7 @@ layout: default
 start_floor=page.floorset resolution_possible=page.resolution_possible %}
 {% endif %}
 
-<h2>Boss: {{ page.boss }}</h2>
+<h2 id="boss">Boss: {{ page.boss }}</h2>
 
 <div id="bossPane">
   {% if page.boss_image %}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -728,9 +728,14 @@ span.rotated {
   color: var(--on-surface);
 }
 
-.searchResult a:hover {
+.searchResult a:hover,
+.searchResult a:focus {
   background-color: var(--surface-highlight);
   color: var(--on-surface-highlight);
+}
+
+.searchResult a:focus {
+  outline: none;
 }
 
 .searchResultTitle {
@@ -742,7 +747,8 @@ span.rotated {
   color: var(--on-surface-dim);
 }
 
-.searchResult a:hover .searchResultMeta {
+.searchResult a:hover .searchResultMeta,
+.searchResult a:focus .searchResultMeta {
   color: var(--on-surface-dim-highlight);
 }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -606,7 +606,25 @@ span.rotated {
   overflow-x: auto;
 }
 
+/* When navigating to #fragment links (e.g. from search results), keep the
+   target heading clear */
+:target,
+h1[id],
+h2[id],
+h3[id],
+h4[id] {
+  scroll-margin-top: 16px;
+}
+
 @media screen and (max-width: 600px) {
+
+  :target,
+  h1[id],
+  h2[id],
+  h3[id],
+  h4[id] {
+    scroll-margin-top: 48px;
+  }
 
   #nav {
     top: 40px;
@@ -636,16 +654,6 @@ span.rotated {
 
   #nav.open {
     display: flex;
-  }
-
-  /* Offset linked position on page so headings aren't hidden behind fixed topnav */
-  h1:before,
-  h2:before {
-    display: block;
-    height: 40px;
-    margin-top: -40px;
-    content: "";
-    visibility: hidden;
   }
 }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -676,3 +676,78 @@ span.rotated {
 .notice .notice-content p:last-child {
   margin-bottom: 0;
 }
+
+#navSearch {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#navSearch svg {
+  flex-shrink: 0;
+}
+
+.searchInput {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px 12px;
+  font-size: 16px;
+  background-color: var(--background);
+  color: var(--on-background-bright);
+  border: 1px solid var(--on-background-dim);
+  border-radius: 4px;
+}
+
+.searchInput:focus {
+  outline: none;
+  border-color: var(--on-surface-highlight);
+}
+
+.searchResults {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+}
+
+.searchResults .searchResult,
+.searchResults .searchEmpty {
+  margin: 0;
+  padding: 0;
+}
+
+.searchResult + .searchResult {
+  border-top: 1px solid var(--background);
+}
+
+.searchResult a {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 12px;
+  text-decoration: none;
+  color: var(--on-surface);
+}
+
+.searchResult a:hover {
+  background-color: var(--surface-highlight);
+  color: var(--on-surface-highlight);
+}
+
+.searchResultTitle {
+  font-weight: 600;
+}
+
+.searchResultMeta {
+  font-size: 0.85em;
+  color: var(--on-surface-dim);
+}
+
+.searchResult a:hover .searchResultMeta {
+  color: var(--on-surface-dim-highlight);
+}
+
+.searchEmpty {
+  padding: 10px 12px;
+  color: var(--on-surface-dim);
+  font-style: italic;
+}

--- a/assets/js/charts.js
+++ b/assets/js/charts.js
@@ -1,4 +1,4 @@
-var charts = (function () {
+const charts = (() => {
   const SVG_NS = 'http://www.w3.org/2000/svg';
 
   return {

--- a/assets/js/floorset.js
+++ b/assets/js/floorset.js
@@ -1,4 +1,4 @@
-(() => {
+const floorset = (() => {
   let activatedFloor = null;
   const floorSelect = document.getElementById("floorSelect");
   const legend = document.getElementById("legendDialog");

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,4 +1,4 @@
-(() => {
+const search = (() => {
   const MIN_QUERY_LENGTH = 2;
   const MAX_RESULTS = 25;
   const DEBOUNCE_MS = 80;

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -145,4 +145,5 @@ const search = (() => {
 
     input.addEventListener('input', onInput);
     input.addEventListener('focus', loadIndex, { once: true });
+  }
 })();

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,0 +1,149 @@
+(() => {
+  const MIN_QUERY_LENGTH = 2;
+  const MAX_RESULTS = 25;
+  const DEBOUNCE_MS = 80;
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+
+  function init() {
+    const input = document.getElementById('searchInput');
+    const resultsList = document.getElementById('searchResults');
+
+    if (!input || !resultsList || typeof MiniSearch === 'undefined') {
+      return;
+    }
+
+    let miniSearch = null;
+    let loadPromise = null;
+    let debounceHandle = null;
+
+    function loadIndex() {
+      if (loadPromise) {
+        return loadPromise;
+      }
+
+      const indexUrl = input.dataset.indexUrl || '/search.json';
+
+      loadPromise = fetch(indexUrl, { credentials: 'same-origin' })
+        .then((response) => {
+          if (!response.ok) {
+            return null;
+          }
+          return response.json();
+        })
+        .then((entries) => {
+          if (!entries) {
+            loadPromise = null;
+            return null;
+          }
+          // This uses minisearch loaded as a global
+          // Expected DOM:
+          // <input id="searchInput" type="search">
+          // <ul id="searchResults"></ul>
+          miniSearch = new MiniSearch({
+            fields: ['title', 'subtitle', 'keywords'],
+            storeFields: ['title', 'subtitle', 'url', 'kind'],
+            searchOptions: {
+              boost: { title: 3, keywords: 1.5 },
+              prefix: true,
+              fuzzy: 0.2,
+              combineWith: 'AND',
+            },
+          });
+          miniSearch.addAll(entries);
+          return miniSearch;
+        })
+        .catch(() => {
+          loadPromise = null;
+          miniSearch = null;
+          return null;
+        });
+
+      return loadPromise;
+    }
+
+    function clearResults() {
+      resultsList.replaceChildren();
+    }
+
+    function renderEmpty(message) {
+      const li = document.createElement('li');
+      li.className = 'searchEmpty';
+      li.textContent = message;
+      resultsList.replaceChildren(li);
+    }
+
+    function renderResults(results) {
+      if (!results.length) {
+        renderEmpty('No results');
+        return;
+      }
+
+      const fragment = document.createDocumentFragment();
+      for (const result of results) {
+        const li = document.createElement('li');
+        li.className = 'searchResult searchResult--' + result.kind;
+
+        const link = document.createElement('a');
+        link.href = result.url;
+
+        const title = document.createElement('span');
+        title.className = 'searchResultTitle';
+        title.textContent = result.title;
+        link.appendChild(title);
+
+        if (result.subtitle) {
+          const subtitle = document.createElement('span');
+          subtitle.className = 'searchResultMeta';
+          subtitle.textContent = result.subtitle;
+          link.appendChild(subtitle);
+        }
+
+        li.appendChild(link);
+        fragment.appendChild(li);
+      }
+
+      resultsList.replaceChildren(fragment);
+    }
+
+    function runSearch(query) {
+      if (!miniSearch) {
+        return;
+      }
+      const results = miniSearch.search(query).slice(0, MAX_RESULTS);
+      renderResults(results);
+    }
+
+    function onInput() {
+      const query = input.value.trim();
+
+      if (debounceHandle !== null) {
+        clearTimeout(debounceHandle);
+        debounceHandle = null;
+      }
+
+      if (query.length < MIN_QUERY_LENGTH) {
+        clearResults();
+        return;
+      }
+
+      debounceHandle = setTimeout(() => {
+        debounceHandle = null;
+        loadIndex().then((index) => {
+          if (!index) {
+            renderEmpty('Search is unavailable');
+            return;
+          }
+          runSearch(query);
+        });
+      }, DEBOUNCE_MS);
+    }
+
+    input.addEventListener('input', onInput);
+    input.addEventListener('focus', loadIndex, { once: true });
+  }
+})();

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -40,10 +40,10 @@ const search = (() => {
             loadPromise = null;
             return null;
           }
-          // This uses minisearch loaded as a global
+          // This uses minisearch loaded as a global.
           // Expected DOM:
-          // <input id="searchInput" type="search">
-          // <ul id="searchResults"></ul>
+          //   <input id="searchInput" type="search">
+          //   <ul id="searchResults"></ul>
           miniSearch = new MiniSearch({
             fields: ['title', 'subtitle', 'keywords'],
             storeFields: ['title', 'subtitle', 'url', 'kind'],
@@ -145,5 +145,4 @@ const search = (() => {
 
     input.addEventListener('input', onInput);
     input.addEventListener('focus', loadIndex, { once: true });
-  }
 })();

--- a/pages/search.md
+++ b/pages/search.md
@@ -1,0 +1,21 @@
+---
+title: Search
+external_scripts:
+  - https://cdn.jsdelivr.net/npm/minisearch@7.1.2/dist/umd/index.min.js
+scripts:
+  - search.js
+---
+
+<div class="surfacePane" markdown="0">
+  <input
+    type="search"
+    id="searchInput"
+    class="searchInput"
+    placeholder="Search pages, floorsets, bosses, enemies…"
+    autocomplete="off"
+    spellcheck="false"
+    autofocus
+    data-index-url="{{ '/search.json' | relative_url }}"
+  />
+  <ul id="searchResults" class="searchResults"></ul>
+</div>

--- a/search.json
+++ b/search.json
@@ -1,0 +1,135 @@
+---
+layout: null
+permalink: /search.json
+sitemap: false
+---
+{%- comment -%}
+================================================================================
+Search index — emitted to /search.json at build time.
+
+Consumed by /assets/js/search.js (MiniSearch). One JSON object per searchable
+item: prose page, floorset, boss, or enemy.
+
+Schema:
+  id        Unique numeric id (required by MiniSearch).
+  kind      One of: "page" | "floorset" | "boss" | "enemy".
+  title     Primary display text.
+  subtitle  Short context line (e.g. "PotD 1-10 · Boss").
+  url       Site-relative URL with optional fragment / query string.
+  keywords  Searchable text blob (alt names, families, ability names, …).
+
+The `sep` variable holds the comma between emitted entries. It starts empty
+and flips to "," after the first entry, so trailing commas never appear no
+matter which entries are skipped.
+================================================================================
+{%- endcomment -%}
+{%- assign dungeon_keys   = "potd,hoh,eo,pt" | split: "," -%}
+{%- assign dungeon_labels = "PotD,HoH,EO,PT" | split: "," -%}
+{%- assign id  = 0  -%}
+{%- assign sep = "" -%}
+[
+{%- comment -%} ──────── Prose pages ──────── {%- endcomment -%}
+{%- for page in site.pages -%}
+  {%- unless page.path contains "pages/" -%}{%- continue -%}{%- endunless -%}
+  {%- unless page.title -%}{%- continue -%}{%- endunless -%}
+{{ sep }}
+{
+  "id": {{ id }},
+  "kind": "page",
+  "title": {{ page.title | jsonify }},
+  "subtitle": "Page",
+  "url": {{ page.url | relative_url | jsonify }},
+  "keywords": {{ page.title | jsonify }}
+}
+  {%- assign id  = id | plus: 1 -%}
+  {%- assign sep = ","          -%}
+{%- endfor -%}
+
+{%- comment -%} ──────── Home (no front-matter title, so emit explicitly) ──────── {%- endcomment -%}
+{{ sep }}
+{
+  "id": {{ id }},
+  "kind": "page",
+  "title": "Home",
+  "subtitle": "Page",
+  "url": {{ "/" | relative_url | jsonify }},
+  "keywords": "home index deep dungeon compendium"
+}
+{%- assign id  = id | plus: 1 -%}
+{%- assign sep = ","          -%}
+
+{%- comment -%} ──────── Floorsets, bosses, enemies (per dungeon) ──────── {%- endcomment -%}
+{%- for dungeon_key in dungeon_keys -%}
+  {%- assign dungeon_label       = dungeon_labels[forloop.index0]    -%}
+  {%- assign floorset_collection = dungeon_key | append: "_floorsets" -%}
+
+  {%- for floorset in site[floorset_collection] -%}
+    {%- assign floorset_title = floorset.title | default: floorset.name -%}
+
+    {%- comment -%} Floorset entry {%- endcomment -%}
+{{ sep }}
+{
+  "id": {{ id }},
+  "kind": "floorset",
+  "title": {{ floorset_title | jsonify }},
+  "subtitle": {{ dungeon_label | append: " · Floorset" | jsonify }},
+  "url": {{ floorset.url | relative_url | jsonify }},
+  "keywords": {{ floorset_title | jsonify }}
+}
+    {%- assign id  = id | plus: 1 -%}
+    {%- assign sep = ","          -%}
+
+    {%- comment -%} Boss entry (skipped if floorset has no boss field) {%- endcomment -%}
+    {%- if floorset.boss -%}
+      {%- capture boss_keywords -%}
+        {{ floorset.boss }}
+        {%- if floorset.boss_abilities -%}
+          {%- for ability in floorset.boss_abilities %} {{ ability.name }}{%- endfor -%}
+        {%- endif -%}
+      {%- endcapture -%}
+{{ sep }}
+{
+  "id": {{ id }},
+  "kind": "boss",
+  "title": {{ floorset.boss | jsonify }},
+  "subtitle": {{ floorset_title | append: " · Boss" | jsonify }},
+  "url": {{ floorset.url | append: "#boss" | relative_url | jsonify }},
+  "keywords": {{ boss_keywords | normalize_whitespace | jsonify }}
+}
+      {%- assign id  = id | plus: 1 -%}
+      {%- assign sep = ","          -%}
+    {%- endif -%}
+
+    {%- comment -%}
+      Enemy entries — sort order MUST match _layouts/floorset.html so the
+      emitted index lines up with the `?enemy=N` parameter consumed by site.js.
+    {%- endcomment -%}
+    {%- assign enemy_collection = dungeon_key | append: "_" | append: floorset.floorset | append: "_enemies" -%}
+    {%- assign enemies_raw      = site[enemy_collection] -%}
+    {%- if enemies_raw -%}
+      {%- assign enemies_sorted = enemies_raw | sort: "end_floor" | sort: "start_floor" | sort: "sort_order" -%}
+      {%- for enemy in enemies_sorted -%}
+        {%- capture enemy_url -%}{{ floorset.url }}?enemy={{ forloop.index0 }}#enemies{%- endcapture -%}
+        {%- capture enemy_subtitle -%}{{ floorset_title }} · Floors {{ enemy.start_floor }}-{{ enemy.end_floor }}{%- endcapture -%}
+        {%- capture enemy_keywords -%}
+          {{ enemy.name }} {{ enemy.nickname }} {{ enemy.family }}
+          {%- if enemy.abilities -%}
+            {%- for ability in enemy.abilities %} {{ ability.name }}{%- endfor -%}
+          {%- endif -%}
+        {%- endcapture -%}
+{{ sep }}
+{
+  "id": {{ id }},
+  "kind": "enemy",
+  "title": {{ enemy.name | jsonify }},
+  "subtitle": {{ enemy_subtitle | jsonify }},
+  "url": {{ enemy_url | relative_url | jsonify }},
+  "keywords": {{ enemy_keywords | normalize_whitespace | jsonify }}
+}
+        {%- assign id  = id | plus: 1 -%}
+        {%- assign sep = ","          -%}
+      {%- endfor -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endfor -%}
+]

--- a/search.json
+++ b/search.json
@@ -80,19 +80,6 @@ matter which entries are skipped.
       {%- assign sep = ","          -%}
     {%- endfor -%}
   {%- endfor -%}
-{{ sep }}
-{
-  "id": {{ id }},
-  "kind": "heading",
-  "title": {{ heading_title | jsonify }},
-  "subtitle": {{ page.title | append: " · Section" | jsonify }},
-  "url": {{ page.url | append: "#" | append: heading_id | relative_url | jsonify }},
-  "keywords": {{ heading_title | jsonify }}
-}
-      {%- assign id  = id | plus: 1 -%}
-      {%- assign sep = ","          -%}
-    {%- endfor -%}
-  {%- endfor -%}
 {%- endfor -%}
 
 {%- comment -%} ──────── Home (emit explicitly) ──────── {%- endcomment -%}

--- a/search.json
+++ b/search.json
@@ -5,10 +5,10 @@ sitemap: false
 ---
 {%- comment -%}
 ================================================================================
-Search index — emitted to /search.json at build time.
+Search index 
 
-Consumed by /assets/js/search.js (MiniSearch). One JSON object per searchable
-item: prose page, floorset, boss, or enemy.
+This file is GENERATED AT BUILD TIME.
+Consumed by /assets/js/search.js (MiniSearch).
 
 Schema:
   id        Unique numeric id (required by MiniSearch).
@@ -29,6 +29,11 @@ matter which entries are skipped.
 {%- assign sep = "" -%}
 [
 {%- comment -%} ──────── Prose pages ──────── {%- endcomment -%}
+{%- comment -%}
+  Heading IDs are emitted by kramdown automatically. The slugs below identify
+  TOC / decorative headings that should NOT appear as search results.
+{%- endcomment -%}
+{%- assign skip_heading_ids = "top,on-this-page" | split: "," -%}
 {%- for page in site.pages -%}
   {%- unless page.path contains "pages/" -%}{%- continue -%}{%- endunless -%}
   {%- unless page.title -%}{%- continue -%}{%- endunless -%}
@@ -43,9 +48,54 @@ matter which entries are skipped.
 }
   {%- assign id  = id | plus: 1 -%}
   {%- assign sep = ","          -%}
+
+  {%- comment -%}
+    Heading entries — extracted from rendered HTML for prose pages. Kramdown
+    emits each heading as `<hN id="slug">Title</hN>`. We split first on the
+    closing `</hN>` to scope each piece to a single heading, then split that
+    piece on `">` to separate slug from title.
+  {%- endcomment -%}
+  {%- assign heading_levels = "h2,h3" | split: "," -%}
+  {%- for level in heading_levels -%}
+    {%- assign open_tag  = "<"  | append: level | append: ' id="' -%}
+    {%- assign close_tag = "</" | append: level | append: ">"     -%}
+    {%- assign sections = page.content | split: open_tag -%}
+    {%- for section in sections offset:1 -%}
+      {%- assign opener = section | split: close_tag | first -%}
+      {%- assign parts = opener | split: '">' -%}
+      {%- assign heading_id = parts[0] -%}
+      {%- assign heading_title = parts[1] | strip_html | strip -%}
+      {%- if skip_heading_ids contains heading_id -%}{%- continue -%}{%- endif -%}
+      {%- if heading_title == "" -%}{%- continue -%}{%- endif -%}
+{{ sep }}
+{
+  "id": {{ id }},
+  "kind": "heading",
+  "title": {{ heading_title | jsonify }},
+  "subtitle": {{ page.title | append: " · Section" | jsonify }},
+  "url": {{ page.url | append: "#" | append: heading_id | relative_url | jsonify }},
+  "keywords": {{ heading_title | jsonify }}
+}
+      {%- assign id  = id | plus: 1 -%}
+      {%- assign sep = ","          -%}
+    {%- endfor -%}
+  {%- endfor -%}
+{{ sep }}
+{
+  "id": {{ id }},
+  "kind": "heading",
+  "title": {{ heading_title | jsonify }},
+  "subtitle": {{ page.title | append: " · Section" | jsonify }},
+  "url": {{ page.url | append: "#" | append: heading_id | relative_url | jsonify }},
+  "keywords": {{ heading_title | jsonify }}
+}
+      {%- assign id  = id | plus: 1 -%}
+      {%- assign sep = ","          -%}
+    {%- endfor -%}
+  {%- endfor -%}
 {%- endfor -%}
 
-{%- comment -%} ──────── Home (no front-matter title, so emit explicitly) ──────── {%- endcomment -%}
+{%- comment -%} ──────── Home (emit explicitly) ──────── {%- endcomment -%}
 {{ sep }}
 {
   "id": {{ id }},


### PR DESCRIPTION
Been wanting this for a while, happy to change looks/design or how it works.

Notes:
- At build time `search.json` is generated
  - works on both `jekyll serve` and `jekyll build`
- New `search.md` page accessibile through icon (it only works on page headers and sub-headers, not content)
- Uses cdn url for https://lucaong.github.io/minisearch/ for quick search (debounced)
  - minisearch is great because we build a search index for more than just direct matche s

https://github.com/user-attachments/assets/47106656-6033-443d-92b5-4ab84d2f1efb

